### PR TITLE
Regex redirects (Beta)

### DIFF
--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Index.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Index.cshtml
@@ -45,8 +45,8 @@
                 </td>
                 <td>
                     <select class="form-select" asp-for="CustomRedirect.RedirectType">
-                        <option selected value="@RedirectType.Permanent">@RedirectType.Permanent</option>
-                        <option value="@RedirectType.Temporary">@RedirectType.Temporary</option>
+                        <option selected value="@RedirectType.Temporary">@RedirectType.Temporary</option>
+                        <option value="@RedirectType.Permanent">@RedirectType.Permanent</option>
                     </select>
                 </td>
                 <td>

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Models/RegexRedirectModel.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Models/RegexRedirectModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 
 namespace Geta.NotFoundHandler.Admin.Pages.Geta.NotFoundHandler.Admin.Models;
@@ -6,7 +7,13 @@ namespace Geta.NotFoundHandler.Admin.Pages.Geta.NotFoundHandler.Admin.Models;
 public class RegexRedirectModel
 {
     public Guid? Id { get; set; }
+    [Required]
+    [Display(Name = "Old URL Regex")]
     public string OldUrlRegex { get; set; }
+    [Required]
+    [Display(Name = "New URL Format")]
     public string NewUrlFormat { get; set; }
+    [Required]
+    [Display(Name = "Order Number")]
     public int OrderNumber { get; set; }
 }

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Models/RegexRedirectModel.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Models/RegexRedirectModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Geta.NotFoundHandler.Admin.Pages.Geta.NotFoundHandler.Admin.Models;
+
+public class RegexRedirectModel
+{
+    public Guid? Id { get; set; }
+    public string OldUrlRegex { get; set; }
+    public string NewUrlFormat { get; set; }
+    public int OrderNumber { get; set; }
+}

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Models/RegexRedirectModel.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Models/RegexRedirectModel.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
 using System.ComponentModel.DataAnnotations;
-using System.Text.RegularExpressions;
 
 namespace Geta.NotFoundHandler.Admin.Pages.Geta.NotFoundHandler.Admin.Models;
 

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using Geta.NotFoundHandler.Core.Providers.RegexRedirects
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin.RegexModel
 
@@ -16,43 +17,77 @@
             </tr>
             </thead>
             <tbody>
-            <tr>
-                <td>
-                    <input type="text" class="form-control" asp-for="RegexRedirect.OrderNumber">
-                    <span asp-validation-for="RegexRedirect.OrderNumber" class="text-danger"></span>
-                </td>
-                <td>
-                    <input type="text" class="form-control" asp-for="RegexRedirect.OldUrlRegex">
-                    <span asp-validation-for="RegexRedirect.OldUrlRegex" class="text-danger"></span>
-                </td>
-                <td>
-                    <input type="text" class="form-control" asp-for="RegexRedirect.NewUrlFormat">
-                    <span asp-validation-for="RegexRedirect.NewUrlFormat" class="text-danger"></span>
-                </td>
-                <td>
-                    <div class="d-grid gap-2">
-                        <button type="submit" class="btn btn-primary"
-                                asp-page-handler="create">
-                            <span data-feather="plus"></span> add
-                        </button>
-                    </div>
-                </td>
-            </tr>
-            @foreach (var item in Model.Items)
+            @if (!Model.IsEditing())
             {
-                <tr class="align-middle">
-                    <td>@item.OrderNumber</td>
-                    <td>@item.OldUrlRegex</td>
-                    <td>@item.NewUrlFormat</td>
+                <tr>
+                    <td>
+                        <input type="text" class="form-control" asp-for="RegexRedirect.OrderNumber">
+                        <span asp-validation-for="RegexRedirect.OrderNumber" class="text-danger"></span>
+                    </td>
+                    <td>
+                        <input type="text" class="form-control" asp-for="RegexRedirect.OldUrlRegex">
+                        <span asp-validation-for="RegexRedirect.OldUrlRegex" class="text-danger"></span>
+                    </td>
+                    <td>
+                        <input type="text" class="form-control" asp-for="RegexRedirect.NewUrlFormat">
+                        <span asp-validation-for="RegexRedirect.NewUrlFormat" class="text-danger"></span>
+                    </td>
                     <td>
                         <div class="d-grid gap-2">
-                            <button type="submit" class="btn btn-danger"
-                                    asp-page-handler="delete" asp-route-id="@item.Id">
-                                <span data-feather="trash-2"></span> delete
+                            <button type="submit" class="btn btn-primary"
+                                    asp-page-handler="create">
+                                <span data-feather="plus"></span> add
                             </button>
                         </div>
                     </td>
                 </tr>
+            }
+            @foreach (var item in Model.Items)
+            {
+                @if (Model.IsEditing(item.Id))
+                {
+                    <tr>
+                        <td>
+                            <input type="text" class="form-control" asp-for="RegexRedirect.OrderNumber">
+                            <span asp-validation-for="RegexRedirect.OrderNumber" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <input type="text" class="form-control" asp-for="RegexRedirect.OldUrlRegex">
+                            <span asp-validation-for="RegexRedirect.OldUrlRegex" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <input type="text" class="form-control" asp-for="RegexRedirect.NewUrlFormat">
+                            <span asp-validation-for="RegexRedirect.NewUrlFormat" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <button type="submit" class="btn btn-primary"
+                                    asp-page-handler="update" asp-route-id="@Model.RegexRedirect.Id">
+                                <span data-feather="edit-2"></span> Update
+                            </button>
+                        </td>
+                    </tr>
+                }
+                else
+                {
+                    <tr class="align-middle">
+                        <td>@item.OrderNumber</td>
+                        <td>@item.OldUrlRegex</td>
+                        <td>@item.NewUrlFormat</td>
+                        <td>
+                            @if (!Model.IsEditing())
+                            {
+                                <button type="submit" class="btn btn-primary"
+                                        asp-page-handler="edit" asp-route-id="@item.Id">
+                                    <span data-feather="edit"></span> Edit
+                                </button>
+                                <button type="submit" class="btn btn-danger"
+                                        asp-page-handler="delete" asp-route-id="@item.Id">
+                                    <span data-feather="trash-2"></span> delete
+                                </button>
+                            }
+                        </td>
+                    </tr>
+                }
             }
             </tbody>
         </table>

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
@@ -1,5 +1,4 @@
 ﻿@page
-@using Geta.NotFoundHandler.Core.Providers.RegexRedirects
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin.RegexModel
 
@@ -13,6 +12,7 @@
                 <th class="col-1">Order Number</th>
                 <th>Old URL Regex</th>
                 <th>New URL Format</th>
+                <th class="col-1"></th>
                 <th class="col-1"></th>
             </tr>
             </thead>
@@ -40,6 +40,7 @@
                             </button>
                         </div>
                     </td>
+                    <td></td>
                 </tr>
             }
             @foreach (var item in Model.Items)
@@ -65,6 +66,7 @@
                                 <span data-feather="edit-2"></span> Update
                             </button>
                         </td>
+                        <td></td>
                     </tr>
                 }
                 else
@@ -76,14 +78,23 @@
                         <td>
                             @if (!Model.IsEditing())
                             {
-                                <button type="submit" class="btn btn-primary"
-                                        asp-page-handler="edit" asp-route-id="@item.Id">
-                                    <span data-feather="edit"></span> Edit
-                                </button>
-                                <button type="submit" class="btn btn-danger"
-                                        asp-page-handler="delete" asp-route-id="@item.Id">
-                                    <span data-feather="trash-2"></span> delete
-                                </button>
+                                <div class="d-grid gap-2">
+                                    <button type="submit" class="btn btn-primary"
+                                            asp-page-handler="edit" asp-route-id="@item.Id">
+                                        <span data-feather="edit"></span> Edit
+                                    </button>
+                                </div>
+                            }
+                        </td>
+                        <td>
+                            @if (!Model.IsEditing())
+                            {
+                                <div class="d-grid gap-2">
+                                    <button type="submit" class="btn btn-danger"
+                                            asp-page-handler="delete" asp-route-id="@item.Id">
+                                        <span data-feather="trash-2"></span> delete
+                                    </button>
+                                </div>
                             }
                         </td>
                     </tr>

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
@@ -1,0 +1,60 @@
+﻿@page
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@model Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin.RegexModel
+
+@await Component.InvokeAsync("Card", new { message = Model.Message })
+
+<form method="post">
+    <div class="table-responsive mt-3">
+        <table class="table table-hover table-sm" aria-label="Redirects">
+            <thead>
+            <tr>
+                <th class="col-1">Order Number</th>
+                <th>Old URL Regex</th>
+                <th>New URL Format</th>
+                <th class="col-1"></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>
+                    <input type="text" class="form-control" asp-for="RegexRedirect.OrderNumber">
+                    <span asp-validation-for="RegexRedirect.OrderNumber" class="text-danger"></span>
+                </td>
+                <td>
+                    <input type="text" class="form-control" asp-for="RegexRedirect.OldUrlRegex">
+                    <span asp-validation-for="RegexRedirect.OldUrlRegex" class="text-danger"></span>
+                </td>
+                <td>
+                    <input type="text" class="form-control" asp-for="RegexRedirect.NewUrlFormat">
+                    <span asp-validation-for="RegexRedirect.NewUrlFormat" class="text-danger"></span>
+                </td>
+                <td>
+                    <div class="d-grid gap-2">
+                        <button type="submit" class="btn btn-primary"
+                                asp-page-handler="create">
+                            <span data-feather="plus"></span> add
+                        </button>
+                    </div>
+                </td>
+            </tr>
+            @foreach (var item in Model.Items)
+            {
+                <tr class="align-middle">
+                    <td>@item.OrderNumber</td>
+                    <td>@item.OldUrlRegex</td>
+                    <td>@item.NewUrlFormat</td>
+                    <td>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-danger"
+                                    asp-page-handler="delete" asp-route-id="@item.Id">
+                                <span data-feather="trash-2"></span> delete
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</form>

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml
@@ -63,7 +63,7 @@
                         <td>
                             <button type="submit" class="btn btn-primary"
                                     asp-page-handler="update" asp-route-id="@Model.RegexRedirect.Id">
-                                <span data-feather="edit-2"></span> Update
+                                <span data-feather="edit-2"></span> update
                             </button>
                         </td>
                         <td></td>
@@ -81,7 +81,7 @@
                                 <div class="d-grid gap-2">
                                     <button type="submit" class="btn btn-primary"
                                             asp-page-handler="edit" asp-route-id="@item.Id">
-                                        <span data-feather="edit"></span> Edit
+                                        <span data-feather="edit"></span> edit
                                     </button>
                                 </div>
                             }

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
@@ -26,6 +26,8 @@ namespace Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin
 
         public IEnumerable<RegexRedirect> Items { get; set; } = Enumerable.Empty<RegexRedirect>();
 
+        private string EditItemId { get; set; }
+
         [BindProperty]
         public RegexRedirectModel RegexRedirect { get; set; }
 
@@ -54,6 +56,36 @@ namespace Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin
             return RedirectToPage();
         }
 
+        public IActionResult OnPostEdit(Guid id)
+        {
+            ModelState.Clear();
+
+            Load();
+
+            EditItemId = id.ToString();
+
+            var redirect = _redirectLoader.Get(id);
+
+            RegexRedirect = new RegexRedirectModel
+            {
+                Id = redirect.Id,
+                OldUrlRegex = redirect.OldUrlRegex.ToString(),
+                NewUrlFormat = redirect.NewUrlFormat,
+                OrderNumber = redirect.OrderNumber
+            };
+
+            return Page();
+        }
+
+        public IActionResult OnPostUpdate(Guid id)
+        {
+            _regexRedirectsService.Update(id,
+                                          RegexRedirect.OldUrlRegex,
+                                          RegexRedirect.NewUrlFormat,
+                                          RegexRedirect.OrderNumber);
+            return RedirectToPage();
+        }
+
         private void Load()
         {
             var items = FindRedirects();
@@ -64,6 +96,16 @@ namespace Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin
         private IList<RegexRedirect> FindRedirects()
         {
             return _redirectLoader.GetAll().ToList();
+        }
+
+        public bool IsEditing(Guid? id)
+        {
+            return id.ToString() == EditItemId;
+        }
+
+        public bool IsEditing()
+        {
+            return !string.IsNullOrEmpty(EditItemId);
         }
     }
 }

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
@@ -79,6 +79,14 @@ public class RegexModel : PageModel
 
     public IActionResult OnPostUpdate(Guid id)
     {
+        if (!ModelState.IsValid)
+        {
+            Load();
+            EditItemId = id.ToString();
+            
+            return Page();
+        }
+        
         _regexRedirectsService.Update(id,
                                       RegexRedirect.OldUrlRegex,
                                       RegexRedirect.NewUrlFormat,

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
@@ -7,105 +7,105 @@ using Geta.NotFoundHandler.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin
+namespace Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin;
+
+public class RegexModel : PageModel
 {
-    public class RegexModel : PageModel
+    private readonly IRegexRedirectLoader _redirectLoader;
+    private readonly IRegexRedirectsService _regexRedirectsService;
+
+    public RegexModel(
+        IRegexRedirectsService regexRedirectsService,
+        IRegexRedirectLoader redirectLoader)
     {
-        private readonly IRegexRedirectsService _regexRedirectsService;
-        private readonly IRegexRedirectLoader _redirectLoader;
+        _regexRedirectsService = regexRedirectsService;
+        _redirectLoader = redirectLoader;
+    }
 
-        public RegexModel(
-            IRegexRedirectsService regexRedirectsService,
-            IRegexRedirectLoader redirectLoader)
-        {
-            _regexRedirectsService = regexRedirectsService;
-            _redirectLoader = redirectLoader;
-        }
+    public string Message { get; set; }
 
-        public string Message { get; set; }
+    public IEnumerable<RegexRedirect> Items { get; set; } = Enumerable.Empty<RegexRedirect>();
 
-        public IEnumerable<RegexRedirect> Items { get; set; } = Enumerable.Empty<RegexRedirect>();
+    private string EditItemId { get; set; }
 
-        private string EditItemId { get; set; }
+    [BindProperty]
+    public RegexRedirectModel RegexRedirect { get; set; }
 
-        [BindProperty]
-        public RegexRedirectModel RegexRedirect { get; set; }
+    public void OnGet()
+    {
+        Load();
+    }
 
-        public void OnGet()
+    public IActionResult OnPostCreate()
+    {
+        if (!ModelState.IsValid)
         {
             Load();
-        }
-
-        public IActionResult OnPostCreate()
-        {
-            if (!ModelState.IsValid)
-            {
-                Load();
-                return Page();
-            }
-
-            _regexRedirectsService.Create(RegexRedirect.OldUrlRegex, RegexRedirect.NewUrlFormat, RegexRedirect.OrderNumber);
-
-            return RedirectToPage();
-        }
-
-        public IActionResult OnPostDelete(Guid id)
-        {
-            _regexRedirectsService.Delete(id);
-
-            return RedirectToPage();
-        }
-
-        public IActionResult OnPostEdit(Guid id)
-        {
-            ModelState.Clear();
-
-            Load();
-
-            EditItemId = id.ToString();
-
-            var redirect = _redirectLoader.Get(id);
-
-            RegexRedirect = new RegexRedirectModel
-            {
-                Id = redirect.Id,
-                OldUrlRegex = redirect.OldUrlRegex.ToString(),
-                NewUrlFormat = redirect.NewUrlFormat,
-                OrderNumber = redirect.OrderNumber
-            };
-
             return Page();
         }
 
-        public IActionResult OnPostUpdate(Guid id)
-        {
-            _regexRedirectsService.Update(id,
-                                          RegexRedirect.OldUrlRegex,
-                                          RegexRedirect.NewUrlFormat,
-                                          RegexRedirect.OrderNumber);
-            return RedirectToPage();
-        }
+        _regexRedirectsService.Create(RegexRedirect.OldUrlRegex, RegexRedirect.NewUrlFormat, RegexRedirect.OrderNumber);
 
-        private void Load()
-        {
-            var items = FindRedirects();
-            Message = $"There are currently stored {items.Count()} Regex redirects.";
-            Items = items;
-        }
+        return RedirectToPage();
+    }
 
-        private IList<RegexRedirect> FindRedirects()
-        {
-            return _redirectLoader.GetAll().ToList();
-        }
+    public IActionResult OnPostDelete(Guid id)
+    {
+        _regexRedirectsService.Delete(id);
 
-        public bool IsEditing(Guid? id)
-        {
-            return id.ToString() == EditItemId;
-        }
+        return RedirectToPage();
+    }
 
-        public bool IsEditing()
+    public IActionResult OnPostEdit(Guid id)
+    {
+        ModelState.Clear();
+
+        Load();
+
+        EditItemId = id.ToString();
+
+        var redirect = _redirectLoader.Get(id);
+
+        RegexRedirect = new RegexRedirectModel
         {
-            return !string.IsNullOrEmpty(EditItemId);
-        }
+            Id = redirect.Id,
+            OldUrlRegex = redirect.OldUrlRegex.ToString(),
+            NewUrlFormat = redirect.NewUrlFormat,
+            OrderNumber = redirect.OrderNumber
+        };
+
+        return Page();
+    }
+
+    public IActionResult OnPostUpdate(Guid id)
+    {
+        _regexRedirectsService.Update(id,
+                                      RegexRedirect.OldUrlRegex,
+                                      RegexRedirect.NewUrlFormat,
+                                      RegexRedirect.OrderNumber);
+        return RedirectToPage();
+    }
+
+    private void Load()
+    {
+        var items = FindRedirects();
+        Message = $"There are currently stored {items.Count()} Regex redirects.";
+        Items = items;
+        RegexRedirect = new RegexRedirectModel { OrderNumber = items.Select(x => x.OrderNumber).Max() + 1 };
+    }
+
+    private IList<RegexRedirect> FindRedirects()
+    {
+        return _redirectLoader.GetAll().ToList();
+    }
+
+    public bool IsEditing(Guid? id)
+    {
+        return id.ToString() == EditItemId;
+    }
+
+    public bool IsEditing()
+    {
+        return !string.IsNullOrEmpty(EditItemId);
     }
 }

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Geta.NotFoundHandler.Admin.Pages.Geta.NotFoundHandler.Admin.Models;
+using Geta.NotFoundHandler.Core.Providers.RegexRedirects;
+using Geta.NotFoundHandler.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin
+{
+    public class RegexModel : PageModel
+    {
+        private readonly IRegexRedirectsService _regexRedirectsService;
+        private readonly IRegexRedirectLoader _redirectLoader;
+
+        public RegexModel(
+            IRegexRedirectsService regexRedirectsService,
+            IRegexRedirectLoader redirectLoader)
+        {
+            _regexRedirectsService = regexRedirectsService;
+            _redirectLoader = redirectLoader;
+        }
+
+        public string Message { get; set; }
+
+        public IEnumerable<RegexRedirect> Items { get; set; } = Enumerable.Empty<RegexRedirect>();
+
+        [BindProperty]
+        public RegexRedirectModel RegexRedirect { get; set; }
+
+        public void OnGet()
+        {
+            Load();
+        }
+
+        public IActionResult OnPostCreate()
+        {
+            if (!ModelState.IsValid)
+            {
+                Load();
+                return Page();
+            }
+
+            _regexRedirectsService.Create(RegexRedirect.OldUrlRegex, RegexRedirect.NewUrlFormat, RegexRedirect.OrderNumber);
+
+            return RedirectToPage();
+        }
+
+        public IActionResult OnPostDelete(Guid id)
+        {
+            _regexRedirectsService.Delete(id);
+
+            return RedirectToPage();
+        }
+
+        private void Load()
+        {
+            var items = FindRedirects();
+            Message = $"There are currently stored {items.Count()} custom Regex redirects.";
+            Items = items;
+        }
+
+        private IList<RegexRedirect> FindRedirects()
+        {
+            return _redirectLoader.GetAll().ToList();
+        }
+    }
+}

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
@@ -83,10 +83,10 @@ public class RegexModel : PageModel
         {
             Load();
             EditItemId = id.ToString();
-            
+
             return Page();
         }
-        
+
         _regexRedirectsService.Update(id,
                                       RegexRedirect.OldUrlRegex,
                                       RegexRedirect.NewUrlFormat,
@@ -99,7 +99,7 @@ public class RegexModel : PageModel
         var items = FindRedirects();
         Message = $"There are currently stored {items.Count()} Regex redirects.";
         Items = items;
-        RegexRedirect = new RegexRedirectModel { OrderNumber = items.Select(x => x.OrderNumber).Max() + 1 };
+        RegexRedirect = new RegexRedirectModel { OrderNumber = items.Select(x => x.OrderNumber).DefaultIfEmpty().Max() + 1 };
     }
 
     private IList<RegexRedirect> FindRedirects()

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Regex.cshtml.cs
@@ -57,7 +57,7 @@ namespace Geta.NotFoundHandler.Admin.Areas.Geta.NotFoundHandler.Admin
         private void Load()
         {
             var items = FindRedirects();
-            Message = $"There are currently stored {items.Count()} custom Regex redirects.";
+            Message = $"There are currently stored {items.Count()} Regex redirects.";
             Items = items;
         }
 

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Shared/_Layout.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Shared/_Layout.cshtml
@@ -47,6 +47,12 @@
                             Redirects
                         </a>
                     </li>
+                     <li class="nav-item">
+                        <a class="nav-link @Active("Regex")" asp-page="./Regex">
+                            <span data-feather="refresh-cw"></span>
+                            Regex Redirects
+                        </a>
+                    </li>
                     <li class="nav-item">
                         <a class="nav-link @Active("Suggestions")" asp-page="./Suggestions">
                             <span data-feather="file-text"></span>

--- a/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Shared/_Layout.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/Geta.NotFoundHandler.Admin/Pages/Shared/_Layout.cshtml
@@ -50,7 +50,7 @@
                      <li class="nav-item">
                         <a class="nav-link @Active("Regex")" asp-page="./Regex">
                             <span data-feather="refresh-cw"></span>
-                            Regex Redirects
+                            Regex Redirects (Beta)
                         </a>
                     </li>
                     <li class="nav-item">

--- a/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
@@ -13,7 +13,7 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Configuration
         public const int CurrentDbVersion = 1;
 
         public bool AutomaticRedirectsEnabled { get; set; }
-        public RedirectType AutomaticRedirectType { get; set; } = RedirectType.Permanent;
+        public RedirectType AutomaticRedirectType { get; set; } = RedirectType.Temporary;
 
         private readonly List<Type> _contentKeyProviders = new();
         public IEnumerable<Type> ContentKeyProviders => _contentKeyProviders;

--- a/src/Geta.NotFoundHandler/Core/INotFoundHandler.cs
+++ b/src/Geta.NotFoundHandler/Core/INotFoundHandler.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
-using Geta.NotFoundHandler.Core.Redirects;
-
 namespace Geta.NotFoundHandler.Core
 {
     /// <summary>
@@ -17,22 +15,5 @@ namespace Geta.NotFoundHandler.Core
         /// <param name="url">The old url which will be redirected</param>
         /// <returns>The new url for the redirect. If no new url has been created, null should be returned instead.</returns>
         RewriteResult RewriteUrl(string url);
-    }
-
-    public class RewriteResult
-    {
-        public static RewriteResult Empty = new RewriteResult { IsEmpty = true };
-        public string NewUrl { get; }
-        public RedirectType RedirectType { get; }
-        public bool IsEmpty { get; private set; }
-
-        private RewriteResult() { }
-
-        public RewriteResult(string newUrl, RedirectType redirectType)
-        {
-            NewUrl = newUrl;
-            RedirectType = redirectType;
-            throw new System.NotImplementedException();
-        }
     }
 }

--- a/src/Geta.NotFoundHandler/Core/INotFoundHandler.cs
+++ b/src/Geta.NotFoundHandler/Core/INotFoundHandler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
+using Geta.NotFoundHandler.Core.Redirects;
+
 namespace Geta.NotFoundHandler.Core
 {
     /// <summary>
@@ -14,6 +16,23 @@ namespace Geta.NotFoundHandler.Core
         /// </summary>
         /// <param name="url">The old url which will be redirected</param>
         /// <returns>The new url for the redirect. If no new url has been created, null should be returned instead.</returns>
-        string RewriteUrl(string url);
+        RewriteResult RewriteUrl(string url);
+    }
+
+    public class RewriteResult
+    {
+        public static RewriteResult Empty = new RewriteResult { IsEmpty = true };
+        public string NewUrl { get; }
+        public RedirectType RedirectType { get; }
+        public bool IsEmpty { get; private set; }
+
+        private RewriteResult() { }
+
+        public RewriteResult(string newUrl, RedirectType redirectType)
+        {
+            NewUrl = newUrl;
+            RedirectType = redirectType;
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Geta.NotFoundHandler.Data;
+
+namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
+
+public class DefaultRegexRedirectsService : IRegexRedirectsService
+{
+    private readonly RegexRedirectFactory _regexRedirectFactory;
+    private readonly IRepository<RegexRedirect> _repository;
+
+    public DefaultRegexRedirectsService(
+        RegexRedirectFactory regexRedirectFactory,
+        IRepository<RegexRedirect> repository)
+    {
+        _regexRedirectFactory = regexRedirectFactory;
+        _repository = repository;
+    }
+
+    public void Create(string oldUrlRegex, string newUrlFormat, int orderNumber)
+    {
+        var regexRedirect = _regexRedirectFactory.CreateNew(oldUrlRegex, newUrlFormat, orderNumber);
+
+        _repository.Save(regexRedirect);
+    }
+
+    public void Update(Guid id, string oldUrlRegex, string newUrlFormat, int orderNumber)
+    {
+        var regexRedirect = _regexRedirectFactory.Create(id, oldUrlRegex, newUrlFormat, orderNumber);
+        _repository.Save(regexRedirect);
+    }
+
+    public void Delete(Guid id)
+    {
+        var regexRedirect = _regexRedirectFactory.CreateForDeletion(id);
+        _repository.Delete(regexRedirect);
+    }
+}

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
@@ -7,15 +7,18 @@ public class DefaultRegexRedirectsService : IRegexRedirectsService
 {
     private readonly RegexRedirectFactory _regexRedirectFactory;
     private readonly IRepository<RegexRedirect> _repository;
+    private readonly IRegexRedirectLoader _redirectLoader;
     private readonly IRegexRedirectOrderUpdater _orderUpdater;
 
     public DefaultRegexRedirectsService(
         RegexRedirectFactory regexRedirectFactory,
         IRepository<RegexRedirect> repository,
+        IRegexRedirectLoader redirectLoader,
         IRegexRedirectOrderUpdater orderUpdater)
     {
         _regexRedirectFactory = regexRedirectFactory;
         _repository = repository;
+        _redirectLoader = redirectLoader;
         _orderUpdater = orderUpdater;
     }
 
@@ -23,20 +26,22 @@ public class DefaultRegexRedirectsService : IRegexRedirectsService
     {
         var regexRedirect = _regexRedirectFactory.CreateNew(oldUrlRegex, newUrlFormat, orderNumber);
         _repository.Save(regexRedirect);
-        _orderUpdater.Update();
+        _orderUpdater.UpdateOrder();
     }
 
     public void Update(Guid id, string oldUrlRegex, string newUrlFormat, int orderNumber)
     {
+        var original = _redirectLoader.Get(id);
+        var isIncrease = original.OrderNumber < orderNumber;
         var regexRedirect = _regexRedirectFactory.Create(id, oldUrlRegex, newUrlFormat, orderNumber);
         _repository.Save(regexRedirect);
-        _orderUpdater.Update();
+        _orderUpdater.UpdateOrder(isIncrease);
     }
 
     public void Delete(Guid id)
     {
         var regexRedirect = _regexRedirectFactory.CreateForDeletion(id);
         _repository.Delete(regexRedirect);
-        _orderUpdater.Update();
+        _orderUpdater.UpdateOrder();
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
 using Geta.NotFoundHandler.Data;
 
 namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/DefaultRegexRedirectsService.cs
@@ -7,31 +7,36 @@ public class DefaultRegexRedirectsService : IRegexRedirectsService
 {
     private readonly RegexRedirectFactory _regexRedirectFactory;
     private readonly IRepository<RegexRedirect> _repository;
+    private readonly IRegexRedirectOrderUpdater _orderUpdater;
 
     public DefaultRegexRedirectsService(
         RegexRedirectFactory regexRedirectFactory,
-        IRepository<RegexRedirect> repository)
+        IRepository<RegexRedirect> repository,
+        IRegexRedirectOrderUpdater orderUpdater)
     {
         _regexRedirectFactory = regexRedirectFactory;
         _repository = repository;
+        _orderUpdater = orderUpdater;
     }
 
     public void Create(string oldUrlRegex, string newUrlFormat, int orderNumber)
     {
         var regexRedirect = _regexRedirectFactory.CreateNew(oldUrlRegex, newUrlFormat, orderNumber);
-
         _repository.Save(regexRedirect);
+        _orderUpdater.Update();
     }
 
     public void Update(Guid id, string oldUrlRegex, string newUrlFormat, int orderNumber)
     {
         var regexRedirect = _regexRedirectFactory.Create(id, oldUrlRegex, newUrlFormat, orderNumber);
         _repository.Save(regexRedirect);
+        _orderUpdater.Update();
     }
 
     public void Delete(Guid id)
     {
         var regexRedirect = _regexRedirectFactory.CreateForDeletion(id);
         _repository.Delete(regexRedirect);
+        _orderUpdater.Update();
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/IRegexRedirectsService.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/IRegexRedirectsService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
+
+public interface IRegexRedirectsService
+{
+    void Create(string oldUrlRegex, string newUrlFormat, int orderNumber);
+    void Update(Guid id, string oldUrlRegex, string newUrlFormat, int orderNumber);
+    void Delete(Guid id);
+}

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/IRegexRedirectsService.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/IRegexRedirectsService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
 
 namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
@@ -5,10 +5,11 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
-public class MemoryCacheRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedirectLoader
+public class MemoryCacheRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedirectLoader, IRegexRedirectOrderUpdater
 {
     private readonly IRepository<RegexRedirect> _repository;
     private readonly IRegexRedirectLoader _redirectLoader;
+    private readonly IRegexRedirectOrderUpdater _orderUpdater;
     private readonly IMemoryCache _cache;
 
     private const string GetAllCacheKey = "RegexRedirects_GetAll";
@@ -16,10 +17,12 @@ public class MemoryCacheRegexRedirectRepository : IRepository<RegexRedirect>, IR
     public MemoryCacheRegexRedirectRepository(
         IRepository<RegexRedirect> repository,
         IRegexRedirectLoader redirectLoader,
+        IRegexRedirectOrderUpdater orderUpdater,
         IMemoryCache cache)
     {
         _repository = repository;
         _redirectLoader = redirectLoader;
+        _orderUpdater = orderUpdater;
         _cache = cache;
     }
 
@@ -47,6 +50,12 @@ public class MemoryCacheRegexRedirectRepository : IRepository<RegexRedirect>, IR
     public void Delete(RegexRedirect entity)
     {
         _repository.Delete(entity);
+        _cache.Remove(GetAllCacheKey);
+    }
+
+    public void Update()
+    {
+        _orderUpdater.Update();
         _cache.Remove(GetAllCacheKey);
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
 using System.Collections.Generic;
 using Geta.NotFoundHandler.Data;
 using Microsoft.Extensions.Caching.Memory;

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
@@ -53,9 +53,9 @@ public class MemoryCacheRegexRedirectRepository : IRepository<RegexRedirect>, IR
         _cache.Remove(GetAllCacheKey);
     }
 
-    public void Update()
+    public void UpdateOrder(bool isIncrease = false)
     {
-        _orderUpdater.Update();
+        _orderUpdater.UpdateOrder(isIncrease);
         _cache.Remove(GetAllCacheKey);
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/MemoryCacheRegexRedirectRepository.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using Geta.NotFoundHandler.Data;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
+
+public class MemoryCacheRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedirectLoader
+{
+    private readonly IRepository<RegexRedirect> _repository;
+    private readonly IRegexRedirectLoader _redirectLoader;
+    private readonly IMemoryCache _cache;
+
+    private const string GetAllCacheKey = "RegexRedirects_GetAll";
+
+    public MemoryCacheRegexRedirectRepository(
+        IRepository<RegexRedirect> repository,
+        IRegexRedirectLoader redirectLoader,
+        IMemoryCache cache)
+    {
+        _repository = repository;
+        _redirectLoader = redirectLoader;
+        _cache = cache;
+    }
+
+    public IEnumerable<RegexRedirect> GetAll()
+    {
+        return _cache.GetOrCreate(GetAllCacheKey,
+                                  cacheEntry =>
+                                  {
+                                      cacheEntry.SlidingExpiration = TimeSpan.FromHours(1);
+                                      return _redirectLoader.GetAll();
+                                  });
+    }
+
+    public RegexRedirect Get(Guid id)
+    {
+        return _redirectLoader.Get(id);
+    }
+
+    public void Save(RegexRedirect entity)
+    {
+        _repository.Save(entity);
+        _cache.Remove(GetAllCacheKey);
+    }
+
+    public void Delete(RegexRedirect entity)
+    {
+        _repository.Delete(entity);
+        _cache.Remove(GetAllCacheKey);
+    }
+}

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
@@ -8,20 +8,25 @@ namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 public class RegexRedirect
 {
-    public RegexRedirect(Regex oldUrlRegex, string newUrlFormat)
+    public RegexRedirect(Regex oldUrlRegex, string newUrlFormat, int orderNumber)
     {
         OldUrlRegex = oldUrlRegex;
         NewUrlFormat = newUrlFormat;
+        OrderNumber = orderNumber;
     }
 
-    public RegexRedirect(Guid id, Regex oldUrlRegex, string newUrlFormat)
+    public RegexRedirect(Guid id, Regex oldUrlRegex, string newUrlFormat, int orderNumber, int timeoutCount)
     {
         Id = id;
         OldUrlRegex = oldUrlRegex;
         NewUrlFormat = newUrlFormat;
+        OrderNumber = orderNumber;
+        TimeoutCount = timeoutCount;
     }
 
     public Guid? Id { get; }
     public Regex OldUrlRegex { get; }
     public string NewUrlFormat { get; }
+    public int OrderNumber { get; }
+    public int TimeoutCount { get; }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
@@ -8,14 +8,7 @@ namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 public class RegexRedirect
 {
-    public RegexRedirect(Regex oldUrlRegex, string newUrlFormat, int orderNumber)
-    {
-        OldUrlRegex = oldUrlRegex;
-        NewUrlFormat = newUrlFormat;
-        OrderNumber = orderNumber;
-    }
-
-    public RegexRedirect(Guid id, Regex oldUrlRegex, string newUrlFormat, int orderNumber, int timeoutCount)
+    public RegexRedirect(Guid? id, Regex oldUrlRegex, string newUrlFormat, int orderNumber, int? timeoutCount)
     {
         Id = id;
         OldUrlRegex = oldUrlRegex;
@@ -28,5 +21,5 @@ public class RegexRedirect
     public Regex OldUrlRegex { get; }
     public string NewUrlFormat { get; }
     public int OrderNumber { get; }
-    public int TimeoutCount { get; }
+    public int? TimeoutCount { get; }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
+
+public class RegexRedirect
+{
+    public RegexRedirect(Regex oldUrlRegex, string newUrlFormat)
+    {
+        OldUrlRegex = oldUrlRegex;
+        NewUrlFormat = newUrlFormat;
+    }
+
+    public RegexRedirect(Guid id, Regex oldUrlRegex, string newUrlFormat)
+    {
+        Id = id;
+        OldUrlRegex = oldUrlRegex;
+        NewUrlFormat = newUrlFormat;
+    }
+
+    public Guid? Id { get; }
+    public Regex OldUrlRegex { get; }
+    public string NewUrlFormat { get; }
+}

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirect.cs
@@ -8,13 +8,22 @@ namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 public class RegexRedirect
 {
-    public RegexRedirect(Guid? id, Regex oldUrlRegex, string newUrlFormat, int orderNumber, int? timeoutCount)
+    public RegexRedirect(
+        Guid? id,
+        Regex oldUrlRegex,
+        string newUrlFormat,
+        int orderNumber,
+        int? timeoutCount,
+        DateTime? createdAt,
+        DateTime? modifiedAt)
     {
         Id = id;
         OldUrlRegex = oldUrlRegex;
         NewUrlFormat = newUrlFormat;
         OrderNumber = orderNumber;
         TimeoutCount = timeoutCount;
+        CreatedAt = createdAt;
+        ModifiedAt = modifiedAt;
     }
 
     public Guid? Id { get; }
@@ -22,4 +31,6 @@ public class RegexRedirect
     public string NewUrlFormat { get; }
     public int OrderNumber { get; }
     public int? TimeoutCount { get; }
+    public DateTime? CreatedAt { get; }
+    public DateTime? ModifiedAt { get; }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
@@ -19,13 +19,17 @@ public class RegexRedirectFactory
         string oldUrlRegex,
         string newUrlFormat,
         int orderNumber,
-        int? timeoutCount = null)
+        int? timeoutCount = null,
+        DateTime? createdAt = null,
+        DateTime? modifiedAt = null)
     {
         return new RegexRedirect(id,
                                  new Regex(oldUrlRegex, RegexOptions.Compiled, _configuration.RegexTimeout),
                                  newUrlFormat,
                                  orderNumber,
-                                 timeoutCount);
+                                 timeoutCount,
+                                 createdAt,
+                                 modifiedAt);
     }
 
     public virtual RegexRedirect CreateNew(string oldUrlRegex, string newUrlFormat, int orderNumber)
@@ -34,11 +38,13 @@ public class RegexRedirectFactory
                                  new Regex(oldUrlRegex, RegexOptions.Compiled, _configuration.RegexTimeout),
                                  newUrlFormat,
                                  orderNumber,
-                                 0);
+                                 0,
+                                 null,
+                                 null);
     }
 
     public virtual RegexRedirect CreateForDeletion(Guid id)
     {
-        return new RegexRedirect(id, null, string.Empty, 0, null);
+        return new RegexRedirect(id, null, string.Empty, 0, null, null, null);
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
+
+public class RegexRedirectFactory
+{
+    private const int Timeout = 100; // TODO: Read from configuration
+
+    public virtual RegexRedirect Create(Guid id, string oldUrlRegex, string newUrlFormat, int orderNumber, int timeoutCount)
+    {
+        return new RegexRedirect(id,
+                                 new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(Timeout)),
+                                 newUrlFormat,
+                                 orderNumber,
+                                 timeoutCount);
+    }
+}

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
@@ -7,12 +7,31 @@ public class RegexRedirectFactory
 {
     private const int Timeout = 100; // TODO: Read from configuration
 
-    public virtual RegexRedirect Create(Guid id, string oldUrlRegex, string newUrlFormat, int orderNumber, int timeoutCount)
+    public virtual RegexRedirect Create(
+        Guid id,
+        string oldUrlRegex,
+        string newUrlFormat,
+        int orderNumber,
+        int? timeoutCount = null)
     {
         return new RegexRedirect(id,
                                  new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(Timeout)),
                                  newUrlFormat,
                                  orderNumber,
                                  timeoutCount);
+    }
+
+    public virtual RegexRedirect CreateNew(string oldUrlRegex, string newUrlFormat, int orderNumber)
+    {
+        return new RegexRedirect(null,
+                                 new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(Timeout)),
+                                 newUrlFormat,
+                                 orderNumber,
+                                 0);
+    }
+
+    public virtual RegexRedirect CreateForDeletion(Guid id)
+    {
+        return new RegexRedirect(id, null, string.Empty, 0, null);
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
@@ -1,11 +1,18 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using Geta.NotFoundHandler.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 public class RegexRedirectFactory
 {
-    private const int Timeout = 100; // TODO: Read from configuration
+    private readonly NotFoundHandlerOptions _configuration;
+
+    public RegexRedirectFactory(IOptions<NotFoundHandlerOptions> options)
+    {
+        _configuration = options.Value;
+    }
 
     public virtual RegexRedirect Create(
         Guid id,
@@ -15,7 +22,7 @@ public class RegexRedirectFactory
         int? timeoutCount = null)
     {
         return new RegexRedirect(id,
-                                 new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(Timeout)),
+                                 new Regex(oldUrlRegex, RegexOptions.Compiled, _configuration.RegexTimeout),
                                  newUrlFormat,
                                  orderNumber,
                                  timeoutCount);
@@ -24,7 +31,7 @@ public class RegexRedirectFactory
     public virtual RegexRedirect CreateNew(string oldUrlRegex, string newUrlFormat, int orderNumber)
     {
         return new RegexRedirect(null,
-                                 new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(Timeout)),
+                                 new Regex(oldUrlRegex, RegexOptions.Compiled, _configuration.RegexTimeout),
                                  newUrlFormat,
                                  orderNumber,
                                  0);

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
 using System.Text.RegularExpressions;
 using Geta.NotFoundHandler.Infrastructure.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectNotFoundHandler.cs
+++ b/src/Geta.NotFoundHandler/Core/Providers/RegexRedirects/RegexRedirectNotFoundHandler.cs
@@ -1,10 +1,12 @@
-﻿using System.Text.RegularExpressions;
-using Geta.NotFoundHandler.Core;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System.Text.RegularExpressions;
 using Geta.NotFoundHandler.Core.Redirects;
 using Geta.NotFoundHandler.Data;
 using Microsoft.Extensions.Logging;
 
-namespace Geta.NotFoundHandler.Providers.RegexRedirects;
+namespace Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 public class RegexRedirectNotFoundHandler : INotFoundHandler
 {
@@ -39,6 +41,8 @@ public class RegexRedirectNotFoundHandler : INotFoundHandler
                                    e.Input,
                                    e.Pattern,
                                    e.MatchTimeout);
+                
+                // TODO: Record timeout failure
             }
         }
 

--- a/src/Geta.NotFoundHandler/Core/Redirects/CustomRedirectCollection.cs
+++ b/src/Geta.NotFoundHandler/Core/Redirects/CustomRedirectCollection.cs
@@ -4,277 +4,281 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 using System.Web;
 using Geta.NotFoundHandler.Infrastructure.Processing;
 
-namespace Geta.NotFoundHandler.Core.Redirects
+namespace Geta.NotFoundHandler.Core.Redirects;
+
+/// <summary>
+/// A collection of custom urls
+/// </summary>
+public class CustomRedirectCollection : IEnumerable<CustomRedirect>
 {
+    private readonly IEnumerable<INotFoundHandler> _providers = new List<INotFoundHandler>();
+
     /// <summary>
-    /// A collection of custom urls
+    /// Hashtable for quick lookup of old urls
     /// </summary>
-    public class CustomRedirectCollection : IEnumerable<CustomRedirect>
+    private readonly Dictionary<string, CustomRedirect> _quickLookupTable = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Cache of URLs sorted ZA for look up of partially matched URLs
+    /// </summary>
+    private KeyValuePair<string, CustomRedirect>[] _redirectsZACache;
+
+    public CustomRedirectCollection()
     {
-        private readonly IEnumerable<INotFoundHandler> _providers = new List<INotFoundHandler>();
+    }
 
-        public CustomRedirectCollection()
+    public CustomRedirectCollection(IEnumerable<INotFoundHandler> providers)
+    {
+        _providers = providers;
+    }
+
+    public IEnumerator<CustomRedirect> GetEnumerator()
+    {
+        return _quickLookupTable.Values.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public CustomRedirect Find(Uri urlNotFound)
+    {
+        // Handle absolute addresses first
+        var url = urlNotFound.AbsoluteUri;
+        var foundRedirect = FindInternal(url);
+
+        // Common case
+        if (foundRedirect == null)
         {
+            url = urlNotFound.PathAndQuery;
+            foundRedirect = FindInternal(url);
         }
 
-        public CustomRedirectCollection(IEnumerable<INotFoundHandler> providers)
+        // Handle legacy databases with encoded values
+        if (foundRedirect == null)
         {
-            _providers = providers;
+            url = HttpUtility.HtmlEncode(url);
+            foundRedirect = FindInternal(url);
         }
 
-        /// <summary>
-        /// Hashtable for quick lookup of old urls
-        /// </summary>
-        private readonly Dictionary<string, CustomRedirect> _quickLookupTable = new Dictionary<string, CustomRedirect>(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// Cache of URLs sorted ZA for look up of partially matched URLs
-        /// </summary>
-        private KeyValuePair<string, CustomRedirect>[] _redirectsZACache;
-
-        public CustomRedirect Find(Uri urlNotFound)
+        if (foundRedirect == null)
         {
-            // Handle absolute addresses first
-            var url = urlNotFound.AbsoluteUri;
-            var foundRedirect = FindInternal(url);
-
-            // Common case
-            if (foundRedirect == null)
-            {
-                url = urlNotFound.PathAndQuery;
-                foundRedirect = FindInternal(url);
-            }
-
-            // Handle legacy databases with encoded values
-            if (foundRedirect == null)
-            {
-                url = HttpUtility.HtmlEncode(url);
-                foundRedirect = FindInternal(url);
-            }
-
-            if (foundRedirect == null)
-            {
-                url = urlNotFound.AbsoluteUri;
-                foundRedirect = FindInProviders(url);
-            }
-
-            return foundRedirect;
+            url = urlNotFound.AbsoluteUri;
+            foundRedirect = FindInProviders(url);
         }
 
-        public void Add(CustomRedirect customRedirect)
+        return foundRedirect;
+    }
+
+    public void Add(CustomRedirect customRedirect)
+    {
+        if (_quickLookupTable.ContainsKey(customRedirect.OldUrl))
         {
-            if (_quickLookupTable.ContainsKey(customRedirect.OldUrl))
-            {
-                _quickLookupTable[customRedirect.OldUrl] = customRedirect;
-                return;
-            }
-
-            // Add to quick look up table too
-            _quickLookupTable.Add(customRedirect.OldUrl, customRedirect);
-
-            // clean cache
-            _redirectsZACache = null;
+            _quickLookupTable[customRedirect.OldUrl] = customRedirect;
+            return;
         }
 
-        private CustomRedirect FindInternal(string url)
+        // Add to quick look up table too
+        _quickLookupTable.Add(customRedirect.OldUrl, customRedirect);
+
+        // clean cache
+        _redirectsZACache = null;
+    }
+
+    private CustomRedirect FindInternal(string url)
+    {
+        url = HttpUtility.UrlDecode(url) ?? string.Empty;
+        if (_quickLookupTable.TryGetValue(url, out var redirect))
         {
-            url = HttpUtility.UrlDecode(url) ?? string.Empty;
-            if (_quickLookupTable.TryGetValue(url, out var redirect))
+            return redirect;
+        }
+
+        // working with local copy to avoid multi-threading issues
+        var redirectsZA = _redirectsZACache;
+        if (redirectsZA == null)
+        {
+            redirectsZA = _quickLookupTable.OrderByDescending(x => x.Key, StringComparer.OrdinalIgnoreCase).ToArray();
+            _redirectsZACache = redirectsZA;
+        }
+
+        var path = url.AsPathSpan();
+        var query = url.AsQuerySpan();
+
+        // No exact match could be done, so we'll check if the 404 url
+        // starts with one of the urls we're matching against. This
+        // will be kind of a wild card match (even though we only check
+        // for the start of the url
+        // Example: http://www.mysite.com/news/mynews.html is not found
+        // We have defined an "<old>/news</old>" entry in the config
+        // file. We will get a match on the /news part of /news/myne...
+        // Depending on the skip wild card append setting, we will either
+        // redirect using the <new> url as is, or we'll append the 404
+        // url to the <new> url.
+        foreach (var redirectPair in redirectsZA)
+        {
+            var oldUrl = redirectPair.Key;
+            if (oldUrl is null)
             {
-                return redirect;
+                continue;
             }
 
-            // working with local copy to avoid multi-threading issues
-            var redirectsZA = _redirectsZACache;
-            if (redirectsZA == null)
-            {
-                redirectsZA = _quickLookupTable.OrderByDescending(x => x.Key, StringComparer.OrdinalIgnoreCase).ToArray();
-                _redirectsZACache = redirectsZA;
-            }
+            var oldPath = oldUrl.AsPathSpan();
+            var oldQuery = oldUrl.AsQuerySpan();
 
-            var path = url.AsPathSpan();
-            var query = url.AsQuerySpan();
-
-            // No exact match could be done, so we'll check if the 404 url
-            // starts with one of the urls we're matching against. This
-            // will be kind of a wild card match (even though we only check
-            // for the start of the url
-            // Example: http://www.mysite.com/news/mynews.html is not found
-            // We have defined an "<old>/news</old>" entry in the config
-            // file. We will get a match on the /news part of /news/myne...
-            // Depending on the skip wild card append setting, we will either
-            // redirect using the <new> url as is, or we'll append the 404
-            // url to the <new> url.
-            foreach (var redirectPair in redirectsZA)
+            // See if this "old" url (the one that cannot be found) starts with one
+            if (path.UrlPathMatch(oldPath) && query.StartsWith(oldQuery, StringComparison.InvariantCultureIgnoreCase))
             {
-                var oldUrl = redirectPair.Key;
-                if (oldUrl is null)
+                var cr = redirectPair.Value;
+                if (cr.State == (int)RedirectState.Ignored)
                 {
-                    continue;
+                    return null;
                 }
 
-                var oldPath = oldUrl.AsPathSpan();
-                var oldQuery = oldUrl.AsQuerySpan();
-
-                // See if this "old" url (the one that cannot be found) starts with one
-                if (path.UrlPathMatch(oldPath) && query.StartsWith(oldQuery, StringComparison.InvariantCultureIgnoreCase))
+                if (cr.WildCardSkipAppend)
                 {
-                    var cr = redirectPair.Value;
-                    if (cr.State == (int)RedirectState.Ignored)
-                    {
-                        return null;
-                    }
+                    // We'll redirect without appending the 404 url
+                    return cr;
+                }
 
-                    if (cr.WildCardSkipAppend)
-                    {
-                        // We'll redirect without appending the 404 url
-                        return cr;
-                    }
-
-                    if (UrlIsOldUrlsSubSegment(path, oldUrl))
-                    {
-                        return CreateSubSegmentRedirect(path, query, cr, oldPath);
-                    }
+                if (UrlIsOldUrlsSubSegment(path, oldUrl))
+                {
+                    return CreateSubSegmentRedirect(path, query, cr, oldPath);
                 }
             }
-
-            return null;
-        }        
-
-        private static CustomRedirect CreateSubSegmentRedirect(ReadOnlySpan<char> path, ReadOnlySpan<char> query, CustomRedirect cr, ReadOnlySpan<char> oldPath)
-        {
-            var redirCopy = new CustomRedirect(cr);
-
-            var newUrl = redirCopy.NewUrl;
-            var newPath = newUrl.AsPathSpan();
-            var newQuery = newUrl.AsQuerySpan();
-
-            var shouldAppendSegment = path.Length > oldPath.Length;
-            var appendSegment = ReadOnlySpan<char>.Empty;
-
-            if (shouldAppendSegment)
-            {
-                appendSegment = path[oldPath.Length..];
-            }
-
-            // Note: Guard against infinite buildup of redirects
-            while (appendSegment.UrlPathMatch(oldPath))
-            {
-                appendSegment = appendSegment[oldPath.Length..];
-            }
-
-            appendSegment = appendSegment.RemoveLeadingSlash();
-
-            var pathHasTrailingSlash = path.EndsWith("/");
-
-            var size = appendSegment.Length + query.Length + newQuery.Length + 1;
-            var builder = new StringBuilder(size);
-
-            BuildPath(newPath, appendSegment, pathHasTrailingSlash, builder);
-
-            var hasQuery = query.Length > 0 || newQuery.Length > 0;
-            var hasEmptyPath = builder.Length == 0;
-
-            if (hasEmptyPath && hasQuery)
-            {
-                builder.Append('/');
-            }
-
-            BuildQuery(query, newQuery, builder);
-
-            redirCopy.NewUrl = builder.ToString();
-
-            return redirCopy;
         }
 
-        private static void BuildPath(ReadOnlySpan<char> path, ReadOnlySpan<char> appendSegment, bool pathHasTrailingSlash, StringBuilder builder)
+        return null;
+    }
+
+    private static CustomRedirect CreateSubSegmentRedirect(
+        ReadOnlySpan<char> path,
+        ReadOnlySpan<char> query,
+        CustomRedirect cr,
+        ReadOnlySpan<char> oldPath)
+    {
+        var redirCopy = new CustomRedirect(cr);
+
+        var newUrl = redirCopy.NewUrl;
+        var newPath = newUrl.AsPathSpan();
+        var newQuery = newUrl.AsQuerySpan();
+
+        var shouldAppendSegment = path.Length > oldPath.Length;
+        var appendSegment = ReadOnlySpan<char>.Empty;
+
+        if (shouldAppendSegment)
         {
-            var hasAppendSegment = appendSegment.Length > 0;
-
-            if (!hasAppendSegment && !pathHasTrailingSlash)
-            {
-                path = path.RemoveTrailingSlash();
-            }
-
-            builder.Append(path);            
-
-            if (hasAppendSegment && !pathHasTrailingSlash)
-            {
-                builder.Append('/');
-            }
-
-            builder.Append(appendSegment);
-
-            if (pathHasTrailingSlash && hasAppendSegment && !appendSegment.EndsWith("/"))
-            {
-                builder.Append('/');
-            }
+            appendSegment = path[oldPath.Length..];
         }
 
-        private static void BuildQuery(ReadOnlySpan<char> baseQuery, ReadOnlySpan<char> newQuery, StringBuilder builder)
+        // Note: Guard against infinite buildup of redirects
+        while (appendSegment.UrlPathMatch(oldPath))
         {
-            var hasIncomingQuery = baseQuery.Length > 0;
-            var hasOutgoingQuery = newQuery.Length > 0;
+            appendSegment = appendSegment[oldPath.Length..];
+        }
 
+        appendSegment = appendSegment.RemoveLeadingSlash();
+
+        var pathHasTrailingSlash = path.EndsWith("/");
+
+        var size = appendSegment.Length + query.Length + newQuery.Length + 1;
+        var builder = new StringBuilder(size);
+
+        BuildPath(newPath, appendSegment, pathHasTrailingSlash, builder);
+
+        var hasQuery = query.Length > 0 || newQuery.Length > 0;
+        var hasEmptyPath = builder.Length == 0;
+
+        if (hasEmptyPath && hasQuery)
+        {
+            builder.Append('/');
+        }
+
+        BuildQuery(query, newQuery, builder);
+
+        redirCopy.NewUrl = builder.ToString();
+
+        return redirCopy;
+    }
+
+    private static void BuildPath(
+        ReadOnlySpan<char> path,
+        ReadOnlySpan<char> appendSegment,
+        bool pathHasTrailingSlash,
+        StringBuilder builder)
+    {
+        var hasAppendSegment = appendSegment.Length > 0;
+
+        if (!hasAppendSegment && !pathHasTrailingSlash)
+        {
+            path = path.RemoveTrailingSlash();
+        }
+
+        builder.Append(path);
+
+        if (hasAppendSegment && !pathHasTrailingSlash)
+        {
+            builder.Append('/');
+        }
+
+        builder.Append(appendSegment);
+
+        if (pathHasTrailingSlash && hasAppendSegment && !appendSegment.EndsWith("/"))
+        {
+            builder.Append('/');
+        }
+    }
+
+    private static void BuildQuery(ReadOnlySpan<char> baseQuery, ReadOnlySpan<char> newQuery, StringBuilder builder)
+    {
+        var hasIncomingQuery = baseQuery.Length > 0;
+        var hasOutgoingQuery = newQuery.Length > 0;
+
+        if (hasIncomingQuery)
+        {
+            builder.Append(baseQuery);
+        }
+
+        if (hasOutgoingQuery && !baseQuery.StartsWith(newQuery))
+        {
             if (hasIncomingQuery)
             {
-                builder.Append(baseQuery);
+                builder.Append('&');
+                builder.Append(newQuery[1..]);
             }
-
-            if (hasOutgoingQuery && !baseQuery.StartsWith(newQuery))
+            else
             {
-                if (hasIncomingQuery)
-                {
-                    builder.Append('&');
-                    builder.Append(newQuery[1..]);
-                }
-                else
-                {
-                    builder.Append(newQuery);
-                }
+                builder.Append(newQuery);
             }
-        }        
+        }
+    }
 
-        private static bool UrlIsOldUrlsSubSegment(ReadOnlySpan<char> url, string oldUrl)
+    private static bool UrlIsOldUrlsSubSegment(ReadOnlySpan<char> url, string oldUrl)
+    {
+        ReadOnlySpan<char> RemoveQueryString(ReadOnlySpan<char> u)
         {
-            ReadOnlySpan<char> RemoveQueryString(ReadOnlySpan<char> u)
-            {
-                var i = u.IndexOf("?", StringComparison.Ordinal);
-                return i < 0 ? u : u[0..i];
-            }
-
-            var normalizedUrlWithoutQuery = RemoveQueryString(url).TrimEnd('/');
-            var normalizedOldUrl = RemoveQueryString(oldUrl).TrimEnd('/');
-            var isSameUrl = normalizedUrlWithoutQuery.Equals(normalizedOldUrl, StringComparison.OrdinalIgnoreCase);
-            var isPartOfOldUrl = normalizedUrlWithoutQuery[0..normalizedOldUrl.Length].StartsWith("/");
-            return isSameUrl || isPartOfOldUrl;
+            var i = u.IndexOf("?", StringComparison.Ordinal);
+            return i < 0 ? u : u[..i];
         }
 
-        private CustomRedirect FindInProviders(string oldUrl)
-        {
-            // If no exact or wildcard match is found, try to parse the url through the custom providers
-            foreach (var provider in _providers)
-            {
-                var newUrl = provider.RewriteUrl(oldUrl);
-                if (newUrl != null) return new CustomRedirect(oldUrl, newUrl);
-            }
-            return null;
-        }
+        var normalizedUrlWithoutQuery = RemoveQueryString(url).TrimEnd('/');
+        var normalizedOldUrl = RemoveQueryString(oldUrl).TrimEnd('/');
+        var isSameUrl = normalizedUrlWithoutQuery.Equals(normalizedOldUrl, StringComparison.OrdinalIgnoreCase);
+        var isPartOfOldUrl = normalizedUrlWithoutQuery[..normalizedOldUrl.Length].StartsWith("/");
+        return isSameUrl || isPartOfOldUrl;
+    }
 
-        public IEnumerator<CustomRedirect> GetEnumerator()
-        {
-            return _quickLookupTable.Values.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+    private CustomRedirect FindInProviders(string oldUrl)
+    {
+        return _providers
+            .Select(provider => provider.RewriteUrl(oldUrl))
+            .Where(rewriteResult => !rewriteResult.IsEmpty)
+            .Select(rewriteResult => new CustomRedirect(oldUrl, rewriteResult.NewUrl, false, rewriteResult.RedirectType))
+            .FirstOrDefault();
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Redirects/RedirectsXmlParser.cs
+++ b/src/Geta.NotFoundHandler/Core/Redirects/RedirectsXmlParser.cs
@@ -155,7 +155,7 @@ namespace Geta.NotFoundHandler.Core.Redirects
                 return redirectType;
             }
 
-            return Redirects.RedirectType.Permanent;
+            return Redirects.RedirectType.Temporary;
         }
     }
 }

--- a/src/Geta.NotFoundHandler/Core/RewriteResult.cs
+++ b/src/Geta.NotFoundHandler/Core/RewriteResult.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using Geta.NotFoundHandler.Core.Redirects;
+
+namespace Geta.NotFoundHandler.Core;
+
+public class RewriteResult
+{
+    public static readonly RewriteResult Empty = new() { IsEmpty = true };
+    public string NewUrl { get; }
+    public RedirectType RedirectType { get; }
+    public bool IsEmpty { get; private set; }
+
+    private RewriteResult() { }
+
+    public RewriteResult(string newUrl, RedirectType redirectType)
+    {
+        NewUrl = newUrl;
+        RedirectType = redirectType;
+    }
+}

--- a/src/Geta.NotFoundHandler/Data/IRegexRedirectLoader.cs
+++ b/src/Geta.NotFoundHandler/Data/IRegexRedirectLoader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
+using System;
 using System.Collections.Generic;
 using Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
@@ -9,4 +10,5 @@ namespace Geta.NotFoundHandler.Data;
 public interface IRegexRedirectLoader
 {
     IEnumerable<RegexRedirect> GetAll();
+    RegexRedirect Get(Guid id);
 }

--- a/src/Geta.NotFoundHandler/Data/IRegexRedirectLoader.cs
+++ b/src/Geta.NotFoundHandler/Data/IRegexRedirectLoader.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Geta.NotFoundHandler.Data;
+
+public interface IRegexRedirectLoader
+{
+    IEnumerable<RegexRedirect> GetAll();
+}
+
+public class RegexRedirect
+{
+    public Regex OldUrlRegex { get; set; }
+    public string NewUrlFormat { get; set; }
+}

--- a/src/Geta.NotFoundHandler/Data/IRegexRedirectLoader.cs
+++ b/src/Geta.NotFoundHandler/Data/IRegexRedirectLoader.cs
@@ -1,15 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Text.RegularExpressions;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 namespace Geta.NotFoundHandler.Data;
 
 public interface IRegexRedirectLoader
 {
     IEnumerable<RegexRedirect> GetAll();
-}
-
-public class RegexRedirect
-{
-    public Regex OldUrlRegex { get; set; }
-    public string NewUrlFormat { get; set; }
 }

--- a/src/Geta.NotFoundHandler/Data/IRegexRedirectOrderUpdater.cs
+++ b/src/Geta.NotFoundHandler/Data/IRegexRedirectOrderUpdater.cs
@@ -2,5 +2,5 @@
 
 public interface IRegexRedirectOrderUpdater
 {
-    public void Update();
+    public void UpdateOrder(bool isIncrease = false);
 }

--- a/src/Geta.NotFoundHandler/Data/IRegexRedirectOrderUpdater.cs
+++ b/src/Geta.NotFoundHandler/Data/IRegexRedirectOrderUpdater.cs
@@ -1,4 +1,7 @@
-﻿namespace Geta.NotFoundHandler.Data;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+namespace Geta.NotFoundHandler.Data;
 
 public interface IRegexRedirectOrderUpdater
 {

--- a/src/Geta.NotFoundHandler/Data/IRegexRedirectOrderUpdater.cs
+++ b/src/Geta.NotFoundHandler/Data/IRegexRedirectOrderUpdater.cs
@@ -1,0 +1,6 @@
+﻿namespace Geta.NotFoundHandler.Data;
+
+public interface IRegexRedirectOrderUpdater
+{
+    public void Update();
+}

--- a/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
@@ -5,12 +5,12 @@ using Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 namespace Geta.NotFoundHandler.Data;
 
-public class SqlRegexRedirectRepository : IRegexRedirectLoader
+public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedirectLoader
 {
     private const string RegexRedirectsTable = "[dbo].[NotFoundHandler.RegexRedirects]";
 
     private const string AllFields = "Id, OldUrlRegex, NewUrlFormat, OrderNumber, TimeoutCount";
-    
+
     private readonly IDataExecutor _dataExecutor;
     private readonly RegexRedirectFactory _regexRedirectFactory;
 
@@ -42,6 +42,68 @@ public class SqlRegexRedirectRepository : IRegexRedirectLoader
             x.Field<string>("NewUrlFormat"),
             x.Field<int>("OrderNumber"),
             x.Field<int>("TimeoutCount"));
+    }
 
+    public void Save(RegexRedirect entity)
+    {
+        if (entity.Id == null)
+        {
+            Create(entity);
+            return;
+        }
+
+        Update(entity);
+    }
+
+    private void Create(RegexRedirect entity)
+    {
+        var sqlCommand = $@"INSERT INTO {RegexRedirectsTable}
+                                    (Id, OldUrlRegex, NewUrlFormat, OrderNumber, TimeoutCount)
+                                    VALUES
+                                    (@id, @oldurlregex, @newurlformat, @ordernumber, @timeoutcount)";
+
+        _dataExecutor.ExecuteNonQuery(
+            sqlCommand,
+            _dataExecutor.CreateGuidParameter("id", Guid.NewGuid()),
+            _dataExecutor.CreateStringParameter("oldurlregex", entity.OldUrlRegex.ToString()),
+            _dataExecutor.CreateStringParameter("newurlformat", entity.NewUrlFormat),
+            _dataExecutor.CreateIntParameter("ordernumber", entity.OrderNumber),
+            _dataExecutor.CreateIntParameter("timeoutcount", 0));
+    }
+
+    private void Update(RegexRedirect entity)
+    {
+        if (!entity.Id.HasValue)
+        {
+            throw new ArgumentException($"{nameof(entity.Id)} is null. Update requires a valid {nameof(entity.Id)} value.");
+        }
+
+        var sqlCommand = $@"UPDATE {RegexRedirectsTable}
+                                    SET OldUrlRegex = @oldurlregex
+                                        ,NewUrlFormat = @newurlformat
+                                        ,OrderNumber = @ordernumber
+                                    WHERE Id = @id";
+
+        _dataExecutor.ExecuteNonQuery(
+            sqlCommand,
+            _dataExecutor.CreateGuidParameter("id", entity.Id.Value),
+            _dataExecutor.CreateStringParameter("oldurlregex", entity.OldUrlRegex.ToString()),
+            _dataExecutor.CreateStringParameter("newurlformat", entity.NewUrlFormat),
+            _dataExecutor.CreateIntParameter("ordernumber", entity.OrderNumber));
+    }
+
+    public void Delete(RegexRedirect entity)
+    {
+        if (!entity.Id.HasValue)
+        {
+            throw new ArgumentException($"{nameof(entity.Id)} is null. Delete requires a valid {nameof(entity.Id)} value.");
+        }
+
+        var sqlCommand = $@"DELETE FROM {RegexRedirectsTable}
+                                    WHERE Id = @id";
+
+        _dataExecutor.ExecuteNonQuery(
+            sqlCommand,
+            _dataExecutor.CreateGuidParameter("id", entity.Id.Value));
     }
 }

--- a/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
@@ -128,13 +128,14 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
             _dataExecutor.CreateGuidParameter("id", entity.Id.Value));
     }
 
-    public void Update()
+    public void UpdateOrder(bool isIncrease = false)
     {
+        var modifiedOrder = isIncrease ? string.Empty : "DESC";
         var sqlCommand = $@"
                 UPDATE x
                 SET x.[OrderNumber] = x.[New_OrderNumber]
                 FROM (
-                      SELECT [OrderNumber], ROW_NUMBER() OVER (ORDER BY [OrderNumber], [ModifiedAt] DESC) AS [New_OrderNumber]
+                      SELECT [OrderNumber], ROW_NUMBER() OVER (ORDER BY [OrderNumber], [ModifiedAt] {modifiedOrder}) AS [New_OrderNumber]
                       FROM {RegexRedirectsTable}
                       ) x
                 WHERE x.[OrderNumber] <> x.[New_OrderNumber]";

--- a/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 
 namespace Geta.NotFoundHandler.Data;
@@ -27,6 +28,18 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
         var dataTable = _dataExecutor.ExecuteQuery(sqlCommand);
 
         return ToRedirects(dataTable);
+    }
+
+    public RegexRedirect Get(Guid id)
+    {
+        var sqlCommand = $@"SELECT {AllFields} FROM {RegexRedirectsTable}
+                                    WHERE Id = @id";
+
+        var dataTable = _dataExecutor.ExecuteQuery(
+            sqlCommand,
+            _dataExecutor.CreateGuidParameter("id", id));
+
+        return ToRedirects(dataTable).FirstOrDefault();
     }
 
     private IEnumerable<RegexRedirect> ToRedirects(DataTable table)

--- a/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
@@ -10,7 +10,7 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
 {
     private const string RegexRedirectsTable = "[dbo].[NotFoundHandler.RegexRedirects]";
 
-    private const string AllFields = "Id, OldUrlRegex, NewUrlFormat, OrderNumber, TimeoutCount";
+    private const string AllFields = "Id, OldUrlRegex, NewUrlFormat, OrderNumber, TimeoutCount, CreatedAt, ModifiedAt";
 
     private readonly IDataExecutor _dataExecutor;
     private readonly RegexRedirectFactory _regexRedirectFactory;
@@ -54,7 +54,9 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
             x.Field<string>("OldUrlRegex"),
             x.Field<string>("NewUrlFormat"),
             x.Field<int>("OrderNumber"),
-            x.Field<int>("TimeoutCount"));
+            x.Field<int>("TimeoutCount"),
+            x.Field<DateTime>("CreatedAt"),
+            x.Field<DateTime>("ModifiedAt"));
     }
 
     public void Save(RegexRedirect entity)
@@ -71,9 +73,11 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
     private void Create(RegexRedirect entity)
     {
         var sqlCommand = $@"INSERT INTO {RegexRedirectsTable}
-                                    (Id, OldUrlRegex, NewUrlFormat, OrderNumber, TimeoutCount)
+                                    (Id, OldUrlRegex, NewUrlFormat, OrderNumber, TimeoutCount, CreatedAt, ModifiedAt)
                                     VALUES
-                                    (@id, @oldurlregex, @newurlformat, @ordernumber, @timeoutcount)";
+                                    (@id, @oldurlregex, @newurlformat, @ordernumber, @timeoutcount, @createdat, @modifiedat)";
+
+        var now = DateTime.UtcNow;
 
         _dataExecutor.ExecuteNonQuery(
             sqlCommand,
@@ -81,7 +85,9 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
             _dataExecutor.CreateStringParameter("oldurlregex", entity.OldUrlRegex.ToString()),
             _dataExecutor.CreateStringParameter("newurlformat", entity.NewUrlFormat),
             _dataExecutor.CreateIntParameter("ordernumber", entity.OrderNumber),
-            _dataExecutor.CreateIntParameter("timeoutcount", 0));
+            _dataExecutor.CreateIntParameter("timeoutcount", 0),
+            _dataExecutor.CreateDateTimeParameter("createdat", now),
+            _dataExecutor.CreateDateTimeParameter("modifiedat", now));
     }
 
     private void Update(RegexRedirect entity)
@@ -94,7 +100,8 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
         var sqlCommand = $@"UPDATE {RegexRedirectsTable}
                                     SET OldUrlRegex = @oldurlregex
                                         ,NewUrlFormat = @newurlformat
-                                        ,OrderNumber = @ordernumber
+                                        ,OrderNumber = @ordernumber,
+                                        ,ModifiedAt = @modifiedat
                                     WHERE Id = @id";
 
         _dataExecutor.ExecuteNonQuery(
@@ -102,7 +109,8 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
             _dataExecutor.CreateGuidParameter("id", entity.Id.Value),
             _dataExecutor.CreateStringParameter("oldurlregex", entity.OldUrlRegex.ToString()),
             _dataExecutor.CreateStringParameter("newurlformat", entity.NewUrlFormat),
-            _dataExecutor.CreateIntParameter("ordernumber", entity.OrderNumber));
+            _dataExecutor.CreateIntParameter("ordernumber", entity.OrderNumber),
+            _dataExecutor.CreateDateTimeParameter("modifiedat", DateTime.UtcNow));
     }
 
     public void Delete(RegexRedirect entity)

--- a/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using Geta.NotFoundHandler.Core.Providers.RegexRedirects;
+
+namespace Geta.NotFoundHandler.Data;
+
+public class SqlRegexRedirectRepository : IRegexRedirectLoader
+{
+    private const string RegexRedirectsTable = "[dbo].[NotFoundHandler.RegexRedirects]";
+
+    private const string AllFields = "Id, OldUrlRegex, NewUrlFormat, OrderNumber, TimeoutCount";
+    
+    private readonly IDataExecutor _dataExecutor;
+    private readonly RegexRedirectFactory _regexRedirectFactory;
+
+    public SqlRegexRedirectRepository(IDataExecutor dataExecutor, RegexRedirectFactory regexRedirectFactory)
+    {
+        _dataExecutor = dataExecutor;
+        _regexRedirectFactory = regexRedirectFactory;
+    }
+
+    public IEnumerable<RegexRedirect> GetAll()
+    {
+        var sqlCommand = $@"SELECT {AllFields} FROM {RegexRedirectsTable}";
+
+        var dataTable = _dataExecutor.ExecuteQuery(sqlCommand);
+
+        return ToRedirects(dataTable);
+    }
+
+    private IEnumerable<RegexRedirect> ToRedirects(DataTable table)
+    {
+        return table.AsEnumerable().Select(ToRedirect);
+    }
+
+    private RegexRedirect ToRedirect(DataRow x)
+    {
+        return _regexRedirectFactory.Create(
+            x.Field<Guid>("Id"),
+            x.Field<string>("OldUrlRegex"),
+            x.Field<string>("NewUrlFormat"),
+            x.Field<int>("OrderNumber"),
+            x.Field<int>("TimeoutCount"));
+
+    }
+}

--- a/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
@@ -23,7 +23,7 @@ public class SqlRegexRedirectRepository : IRepository<RegexRedirect>, IRegexRedi
 
     public IEnumerable<RegexRedirect> GetAll()
     {
-        var sqlCommand = $@"SELECT {AllFields} FROM {RegexRedirectsTable}";
+        var sqlCommand = $@"SELECT {AllFields} FROM {RegexRedirectsTable} ORDER BY OrderNumber";
 
         var dataTable = _dataExecutor.ExecuteQuery(sqlCommand);
 

--- a/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlRegexRedirectRepository.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
@@ -13,6 +13,7 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
         public int BufferSize { get; set; } = 30;
         public int ThreshHold { get; set; } = 5;
         public FileNotFoundMode HandlerMode { get; set; } = FileNotFoundMode.On;
+        public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
 
         public string[] IgnoredResourceExtensions { get; set; } =
             {"jpg", "gif", "png", "css", "js", "ico", "swf", "woff"};

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
@@ -9,7 +9,7 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
 {
     public class NotFoundHandlerOptions
     {
-        public const int CurrentDbVersion = 1;
+        public const int CurrentDbVersion = 2;
         public int BufferSize { get; set; } = 30;
         public int ThreshHold { get; set; } = 5;
         public FileNotFoundMode HandlerMode { get; set; } = FileNotFoundMode.On;

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -58,8 +58,15 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
             services.AddTransient<IRepository<RegexRedirect>>(
                 x => new MemoryCacheRegexRedirectRepository(x.GetRequiredService<SqlRegexRedirectRepository>(),
                                                             x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<SqlRegexRedirectRepository>(),
                                                             x.GetRequiredService<IMemoryCache>()));
-            services.AddTransient<IRegexRedirectLoader>(x => new MemoryCacheRegexRedirectRepository(
+            services.AddTransient<IRegexRedirectLoader>(
+                x => new MemoryCacheRegexRedirectRepository(x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<IMemoryCache>()));
+            services.AddTransient<IRegexRedirectOrderUpdater>(
+                x => new MemoryCacheRegexRedirectRepository(x.GetRequiredService<SqlRegexRedirectRepository>(),
                                                             x.GetRequiredService<SqlRegexRedirectRepository>(),
                                                             x.GetRequiredService<SqlRegexRedirectRepository>(),
                                                             x.GetRequiredService<IMemoryCache>()));

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -53,7 +53,9 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
 
             services.AddTransient<RegexRedirectFactory>();
             services.AddTransient<INotFoundHandler, RegexRedirectNotFoundHandler>();
+            services.AddTransient<IRepository<RegexRedirect>, SqlRegexRedirectRepository>();
             services.AddTransient<IRegexRedirectLoader, SqlRegexRedirectRepository>();
+            services.AddTransient<IRegexRedirectsService, DefaultRegexRedirectsService>();
 
             var providerOptions = new NotFoundHandlerOptions();
             setupAction(providerOptions);

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Geta.NotFoundHandler.Core.Suggestions;
 using Geta.NotFoundHandler.Data;
 using Geta.NotFoundHandler.Infrastructure.Initialization;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -53,8 +54,15 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
 
             services.AddTransient<RegexRedirectFactory>();
             services.AddTransient<INotFoundHandler, RegexRedirectNotFoundHandler>();
-            services.AddTransient<IRepository<RegexRedirect>, SqlRegexRedirectRepository>();
-            services.AddTransient<IRegexRedirectLoader, SqlRegexRedirectRepository>();
+            services.AddTransient<SqlRegexRedirectRepository>();
+            services.AddTransient<IRepository<RegexRedirect>>(
+                x => new MemoryCacheRegexRedirectRepository(x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<IMemoryCache>()));
+            services.AddTransient<IRegexRedirectLoader>(x => new MemoryCacheRegexRedirectRepository(
+                                                            x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<SqlRegexRedirectRepository>(),
+                                                            x.GetRequiredService<IMemoryCache>()));
             services.AddTransient<IRegexRedirectsService, DefaultRegexRedirectsService>();
 
             var providerOptions = new NotFoundHandlerOptions();

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Geta.NotFoundHandler.Core;
+using Geta.NotFoundHandler.Core.Providers.RegexRedirects;
 using Geta.NotFoundHandler.Core.Redirects;
 using Geta.NotFoundHandler.Core.Suggestions;
 using Geta.NotFoundHandler.Data;
@@ -50,11 +51,15 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
             services.AddTransient<ISuggestionLoader, SqlSuggestionRepository>();
             services.AddTransient<ISuggestionRepository, SqlSuggestionRepository>();
 
+            services.AddTransient<RegexRedirectFactory>();
+            services.AddTransient<INotFoundHandler, RegexRedirectNotFoundHandler>();
+            services.AddTransient<IRegexRedirectLoader, SqlRegexRedirectRepository>();
+
             var providerOptions = new NotFoundHandlerOptions();
             setupAction(providerOptions);
             foreach (var provider in providerOptions.Providers)
             {
-                services.AddSingleton(typeof(INotFoundHandler), provider);
+                services.AddTransient(typeof(INotFoundHandler), provider);
             }
 
             services.AddOptions<NotFoundHandlerOptions>().Configure<IConfiguration>((options, configuration) =>

--- a/src/Geta.NotFoundHandler/Infrastructure/Initialization/Upgrader.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Initialization/Upgrader.cs
@@ -131,7 +131,7 @@ public class Upgrader
                                         [NewUrlFormat] [nvarchar](2000) NOT NULL,
                                         [OrderNumber] [int] NOT NULL,
                                         [TimeoutCount] [int] NOT NULL,
-                                        CONSTRAINT [PK_NotFoundHandlerRedirects] PRIMARY KEY CLUSTERED ([Id] ASC) ON [PRIMARY]
+                                        CONSTRAINT [PK_NotFoundHandlerRegexRedirects] PRIMARY KEY CLUSTERED ([Id] ASC) ON [PRIMARY]
                                         ) ON [PRIMARY]";
         var created = _dataExecutor.ExecuteNonQuery(createTableScript);
         _logger.LogInformation("Create NotFoundHandler regex redirects table END");

--- a/src/Geta.NotFoundHandler/Infrastructure/Initialization/Upgrader.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Initialization/Upgrader.cs
@@ -131,6 +131,8 @@ public class Upgrader
                                         [NewUrlFormat] [nvarchar](2000) NOT NULL,
                                         [OrderNumber] [int] NOT NULL,
                                         [TimeoutCount] [int] NOT NULL,
+                                        [CreatedAt] [datetime] NOT NULL,
+                                        [ModifiedAt] [datetime] NOT NULL,
                                         CONSTRAINT [PK_NotFoundHandlerRegexRedirects] PRIMARY KEY CLUSTERED ([Id] ASC) ON [PRIMARY]
                                         ) ON [PRIMARY]";
         var created = _dataExecutor.ExecuteNonQuery(createTableScript);

--- a/src/Geta.NotFoundHandler/Infrastructure/Initialization/Upgrader.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Initialization/Upgrader.cs
@@ -5,67 +5,72 @@ using Geta.NotFoundHandler.Data;
 using Geta.NotFoundHandler.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace Geta.NotFoundHandler.Infrastructure.Initialization
+namespace Geta.NotFoundHandler.Infrastructure.Initialization;
+
+public class Upgrader
 {
-    public class Upgrader
+    private const string SuggestionsTable = "[dbo].[NotFoundHandler.Suggestions]";
+    private const string RedirectsTable = "[dbo].[NotFoundHandler.Redirects]";
+    private const string RegexRedirectsTable = "[dbo].[NotFoundHandler.RegexRedirects]";
+    private readonly IDataExecutor _dataExecutor;
+    private readonly ILogger<Upgrader> _logger;
+
+    public Upgrader(
+        ILogger<Upgrader> logger,
+        IDataExecutor dataExecutor)
     {
-        private readonly ILogger<Upgrader> _logger;
-        private readonly IDataExecutor _dataExecutor;
+        _logger = logger;
+        _dataExecutor = dataExecutor;
+    }
 
-        private const string SuggestionsTable = "[dbo].[NotFoundHandler.Suggestions]";
-        private const string RedirectsTable = "[dbo].[NotFoundHandler.Redirects]";
-
-        public Upgrader(
-            ILogger<Upgrader> logger,
-            IDataExecutor dataExecutor)
+    public void Start()
+    {
+        _logger.LogDebug("Initializing NotFoundHandler version check");
+        var version = GetVersionNumber();
+        if (version == NotFoundHandlerOptions.CurrentDbVersion)
         {
-            _logger = logger;
-            _dataExecutor = dataExecutor;
+            return;
         }
 
-        public void Start()
+        _logger.LogDebug("Older version found. Version nr. : {Version}", version);
+
+        if (version == -1)
         {
-            _logger.LogDebug("Initializing NotFoundHandler version check");
-            var version = GetVersionNumber();
-            if (version == NotFoundHandlerOptions.CurrentDbVersion)
-            {
-                return;
-            }
+            Create();
+        }
+        else
+        {
+            Upgrade();
+        }
+    }
 
-            _logger.LogDebug("Older version found. Version nr. : {Version}", version);
+    /// <summary>
+    /// Create redirects and suggestions tables and SP for version number
+    /// </summary>
+    private void Create()
+    {
+        var created = CreateRedirectsTable();
 
-            if (version == -1)
-            {
-                Create();
-            }
-            else
-            {
-                Upgrade();
-            }
+        if (created)
+        {
+            created = CreateSuggestionsTable();
         }
 
-        /// <summary>
-        /// Create redirects and suggestions tables and SP for version number
-        /// </summary>
-        private void Create()
+        if (created)
         {
-            var created = CreateRedirectsTable();
-
-            if (created)
-            {
-                created = CreateSuggestionsTable();
-            }
-
-            if (created)
-            {
-                CreateVersionNumberSp();
-            }
+            created = CreateRegexRedirectsTable();
         }
 
-        private bool CreateRedirectsTable()
+        if (created)
         {
-            _logger.LogInformation("Create NotFoundHandler redirects table START");
-            var createTableScript = @$"CREATE TABLE {RedirectsTable} (
+            CreateVersionNumberSp();
+        }
+    }
+
+    private bool CreateRedirectsTable()
+    {
+        _logger.LogInformation("Create NotFoundHandler redirects table START");
+        var createTableScript = @$"CREATE TABLE {RedirectsTable} (
                                         [Id] [uniqueidentifier] NOT NULL,
                                         [OldUrl] [nvarchar](2000) NOT NULL,
                                         [NewUrl] [nvarchar](2000) NOT NULL,
@@ -74,102 +79,128 @@ namespace Geta.NotFoundHandler.Infrastructure.Initialization
                                         [RedirectType] [int] NOT NULL,
                                         CONSTRAINT [PK_NotFoundHandlerRedirects] PRIMARY KEY CLUSTERED ([Id] ASC) ON [PRIMARY]
                                         ) ON [PRIMARY]";
-            var created = _dataExecutor.ExecuteNonQuery(createTableScript);
-            _logger.LogInformation("Create NotFoundHandler redirects table END");
+        var created = _dataExecutor.ExecuteNonQuery(createTableScript);
+        _logger.LogInformation("Create NotFoundHandler redirects table END");
 
-            return created;
-        }
+        return created;
+    }
 
-        private bool CreateSuggestionsTable()
-        {
-            _logger.LogInformation("Create NotFoundHandler suggestions table START");
-            var createTableScript = @$"CREATE TABLE {SuggestionsTable} (
+    private bool CreateSuggestionsTable()
+    {
+        _logger.LogInformation("Create NotFoundHandler suggestions table START");
+        var createTableScript = @$"CREATE TABLE {SuggestionsTable} (
                                         [ID] [int] IDENTITY(1,1) NOT NULL,
                                         [OldUrl] [nvarchar](2000) NOT NULL,
                                         [Requested] [datetime] NULL,
                                         [Referer] [nvarchar](2000) NULL
                                         ) ON [PRIMARY]";
-            var created = _dataExecutor.ExecuteNonQuery(createTableScript);
-            _logger.LogInformation("Create NotFoundHandler suggestions table END");
+        var created = _dataExecutor.ExecuteNonQuery(createTableScript);
+        _logger.LogInformation("Create NotFoundHandler suggestions table END");
 
-            if (created)
-            {
-                created = CreateSuggestionsTableIndex();
-            }
-
-            return created;
-        }
-
-        private bool CreateSuggestionsTableIndex()
+        if (created)
         {
-            _logger.LogInformation("Create suggestions table clustered index START");
-            var clusteredIndex =
-                $"CREATE CLUSTERED INDEX NotFoundHandlerSuggestions_ID ON {SuggestionsTable} (ID)";
-
-            var created = _dataExecutor.ExecuteNonQuery(clusteredIndex);
-            if (!created)
-            {
-                _logger.LogError(
-                    "An error occurred during the creation of the NotFoundHandler redirects clustered index. Canceling");
-            }
-
-            _logger.LogInformation("Create suggestions table clustered index END");
-            return created;
+            created = CreateSuggestionsTableIndex();
         }
 
-        private void Upgrade()
+        return created;
+    }
+
+    private bool CreateSuggestionsTableIndex()
+    {
+        _logger.LogInformation("Create suggestions table clustered index START");
+        var clusteredIndex =
+            $"CREATE CLUSTERED INDEX NotFoundHandlerSuggestions_ID ON {SuggestionsTable} (ID)";
+
+        var created = _dataExecutor.ExecuteNonQuery(clusteredIndex);
+        if (!created)
+        {
+            _logger.LogError(
+                "An error occurred during the creation of the NotFoundHandler redirects clustered index. Canceling");
+        }
+
+        _logger.LogInformation("Create suggestions table clustered index END");
+        return created;
+    }
+
+    private bool CreateRegexRedirectsTable()
+    {
+        _logger.LogInformation("Create NotFoundHandler regex redirects table START");
+        var createTableScript = @$"CREATE TABLE {RegexRedirectsTable} (
+                                        [Id] [uniqueidentifier] NOT NULL,
+                                        [OldUrlRegex] [nvarchar](2000) NOT NULL,
+                                        [NewUrlFormat] [nvarchar](2000) NOT NULL,
+                                        [OrderNumber] [int] NOT NULL,
+                                        [TimeoutCount] [int] NOT NULL,
+                                        CONSTRAINT [PK_NotFoundHandlerRedirects] PRIMARY KEY CLUSTERED ([Id] ASC) ON [PRIMARY]
+                                        ) ON [PRIMARY]";
+        var created = _dataExecutor.ExecuteNonQuery(createTableScript);
+        _logger.LogInformation("Create NotFoundHandler regex redirects table END");
+
+        return created;
+    }
+
+    private void Upgrade()
+    {
+        var updated = UpdateRegexRedirectsTable();
+
+        if (updated)
         {
             UpdateVersionNumber();
         }
+    }
 
-        private void CreateVersionNumberSp()
+    private bool UpdateRegexRedirectsTable()
+    {
+        return TableExists(RegexRedirectsTable) || CreateRegexRedirectsTable();
+    }
+
+    private void CreateVersionNumberSp()
+    {
+        _logger.LogInformation("Create NotFoundHandler version SP START");
+        var versionSp =
+            $@"CREATE PROCEDURE [dbo].[notfoundhandler_version] AS RETURN {NotFoundHandlerOptions.CurrentDbVersion}";
+
+        var created = _dataExecutor.ExecuteNonQuery(versionSp);
+
+        if (!created)
         {
-            _logger.LogInformation("Create NotFoundHandler version SP START");
-            var versionSp =
-                $@"CREATE PROCEDURE [dbo].[notfoundhandler_version] AS RETURN {NotFoundHandlerOptions.CurrentDbVersion}";
-
-            var created = _dataExecutor.ExecuteNonQuery(versionSp);
-
-            if (!created)
-            {
-                _logger.LogError(
-                    "An error occurred during the creation of the NotFoundHandler version stored procedure. Canceling");
-            }
-
-            _logger.LogInformation("Create NotFoundHandler version SP END");
+            _logger.LogError(
+                "An error occurred during the creation of the NotFoundHandler version stored procedure. Canceling");
         }
 
-        private int GetVersionNumber()
-        {
-            var sqlCommand = "dbo.notfoundhandler_version";
-            return _dataExecutor.ExecuteStoredProcedure(sqlCommand);
-        }
+        _logger.LogInformation("Create NotFoundHandler version SP END");
+    }
 
-        private void UpdateVersionNumber()
-        {
-            var versionSp =
-                $@"ALTER PROCEDURE [dbo].[notfoundhandler_version] AS RETURN {NotFoundHandlerOptions.CurrentDbVersion}";
-            _dataExecutor.ExecuteNonQuery(versionSp);
-        }
+    private int GetVersionNumber()
+    {
+        var sqlCommand = "dbo.notfoundhandler_version";
+        return _dataExecutor.ExecuteStoredProcedure(sqlCommand);
+    }
 
-        private bool TableExists(string tableName)
-        {
-            var cmd = $@"SELECT *
+    private void UpdateVersionNumber()
+    {
+        var versionSp =
+            $@"ALTER PROCEDURE [dbo].[notfoundhandler_version] AS RETURN {NotFoundHandlerOptions.CurrentDbVersion}";
+        _dataExecutor.ExecuteNonQuery(versionSp);
+    }
+
+    private bool TableExists(string tableName)
+    {
+        var cmd = $@"SELECT *
                  FROM INFORMATION_SCHEMA.TABLES
                  WHERE TABLE_SCHEMA = 'dbo'
                  AND  TABLE_NAME = '{tableName}'";
-            var num = _dataExecutor.ExecuteScalar(cmd);
-            return num != 0;
-        }
+        var num = _dataExecutor.ExecuteScalar(cmd);
+        return num != 0;
+    }
 
-        private bool ColumnExists(string tableName, string columnName)
-        {
-            var cmd = $@"SELECT 1
+    private bool ColumnExists(string tableName, string columnName)
+    {
+        var cmd = $@"SELECT 1
                         FROM sys.columns
                         WHERE Name = '{columnName}'
                         AND  Object_ID = Object_ID(N'dbo.[{tableName}]')";
-            var num = _dataExecutor.ExecuteScalar(cmd);
-            return num != 0;
-        }
+        var num = _dataExecutor.ExecuteScalar(cmd);
+        return num != 0;
     }
 }

--- a/src/Geta.NotFoundHandler/Providers/RegexRedirects/RegexRedirectNotFoundHandler.cs
+++ b/src/Geta.NotFoundHandler/Providers/RegexRedirects/RegexRedirectNotFoundHandler.cs
@@ -1,0 +1,47 @@
+﻿using System.Text.RegularExpressions;
+using Geta.NotFoundHandler.Core;
+using Geta.NotFoundHandler.Core.Redirects;
+using Geta.NotFoundHandler.Data;
+using Microsoft.Extensions.Logging;
+
+namespace Geta.NotFoundHandler.Providers.RegexRedirects;
+
+public class RegexRedirectNotFoundHandler : INotFoundHandler
+{
+    private readonly IRegexRedirectLoader _regexRedirectLoader;
+    private readonly ILogger<RegexRedirectNotFoundHandler> _logger;
+
+    public RegexRedirectNotFoundHandler(IRegexRedirectLoader regexRedirectLoader, ILogger<RegexRedirectNotFoundHandler> logger)
+    {
+        _regexRedirectLoader = regexRedirectLoader;
+        _logger = logger;
+    }
+
+    public RewriteResult RewriteUrl(string url)
+    {
+        var regexRedirects = _regexRedirectLoader.GetAll();
+
+        foreach (var redirect in regexRedirects)
+        {
+            try
+            {
+                var match = redirect.OldUrlRegex.Match(url);
+                if (match.Success)
+                {
+                    var newUrl = match.Result(redirect.NewUrlFormat);
+                    return new RewriteResult(newUrl, RedirectType.Temporary);
+                }
+            }
+            catch (RegexMatchTimeoutException e)
+            {
+                _logger.LogWarning(e,
+                                   "Regex URL match timed out. Url: {Url}; Regex: {Regex}; Timeout: {Timeout}",
+                                   e.Input,
+                                   e.Pattern,
+                                   e.MatchTimeout);
+            }
+        }
+
+        return RewriteResult.Empty;
+    }
+}

--- a/tests/Geta.NotFoundHandler.Tests/CustomRedirectCollectionTests.cs
+++ b/tests/Geta.NotFoundHandler.Tests/CustomRedirectCollectionTests.cs
@@ -257,7 +257,7 @@ namespace Geta.NotFoundHandler.Tests
         {
             var provider = A.Fake<INotFoundHandler>();
             A.CallTo(() => provider.RewriteUrl(A<string>._)).Returns(null);
-            A.CallTo(() => provider.RewriteUrl(oldUrl)).Returns(newUrl);
+            A.CallTo(() => provider.RewriteUrl(oldUrl)).Returns(new RewriteResult(newUrl, RedirectType.Temporary));
             _providers.Add(provider);
         }
 

--- a/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
+++ b/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
@@ -53,6 +53,8 @@ public class RegexNotFoundHandlerTests
     {
         return new RegexRedirect(Guid.NewGuid(),
                                  new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(100)),
-                                 newUrlFormat);
+                                 newUrlFormat,
+                                 1,
+                                 0);
     }
 }

--- a/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
+++ b/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
@@ -55,6 +55,8 @@ public class RegexNotFoundHandlerTests
                                  new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(100)),
                                  newUrlFormat,
                                  orderNumber,
-                                 timoutCount);
+                                 timoutCount,
+                                 DateTime.UtcNow,
+                                 DateTime.UtcNow);
     }
 }

--- a/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
+++ b/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
@@ -49,12 +49,12 @@ public class RegexNotFoundHandlerTests
         Assert.Equal("/catalog-content/redirect-by-code?code=I-123&a=b", result.NewUrl);
     }
 
-    private static RegexRedirect RegexRedirect(string oldUrlRegex, string newUrlFormat)
+    private static RegexRedirect RegexRedirect(string oldUrlRegex, string newUrlFormat, int orderNumber = 1, int timoutCount = 0)
     {
         return new RegexRedirect(Guid.NewGuid(),
                                  new Regex(oldUrlRegex, RegexOptions.Compiled, TimeSpan.FromMilliseconds(100)),
                                  newUrlFormat,
-                                 1,
-                                 0);
+                                 orderNumber,
+                                 timoutCount);
     }
 }

--- a/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
+++ b/tests/Geta.NotFoundHandler.Tests/Providers/RegexNotFoundHandlerTests.cs
@@ -1,0 +1,23 @@
+﻿using Geta.NotFoundHandler.Providers;
+using Geta.NotFoundHandler.Providers.RegexRedirects;
+using Xunit;
+
+namespace Geta.NotFoundHandler.Tests.Providers;
+
+public class RegexNotFoundHandlerTests
+{
+    private readonly RegexRedirectNotFoundHandler _sut;
+
+    public RegexNotFoundHandlerTests()
+    {
+        _sut = new RegexRedirectNotFoundHandler();
+    }
+
+    [Fact]
+    public void RewriteUrl_regex_matches_url()
+    {
+        var result = _sut.RewriteUrl("https://test.example.com/I-123?a=b");
+
+
+    }
+}


### PR DESCRIPTION
- It adds a regex redirects
- BREAKING CHANGE: By default, now Temporary redirect type is set

### Regex redirect usage
Create a redirect with a named captured group, for example: `(?<code>I-[^=?]+)[?]{0,1}(?<query>.*)`.
Then add a result URL format: `/catalog-content/redirect-by-code?code=${code}&${query}`

The syntax is .NET Regex substitutions: https://learn.microsoft.com/en-us/dotnet/standard/base-types/substitutions-in-regular-expressions

P.S. Documentation and hints on the page will follow in a separate PR.