### PR TITLE
Show modal in same position (height) as trigger of modal

### DIFF
--- a/src/Geta.NotFoundHandler.Admin/Areas/GetaNotFoundHandlerAdmin/Pages/Suggestions.cshtml
+++ b/src/Geta.NotFoundHandler.Admin/Areas/GetaNotFoundHandlerAdmin/Pages/Suggestions.cshtml
@@ -81,7 +81,7 @@
                         </div>
                     </div>
                     <div class="d-grid gap-2">
-                        <button type="submit" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#@referersModalId">
+                        <button type="submit" class="btn btn-secondary modal-trigger" data-bs-toggle="modal" data-bs-target="#@referersModalId">
                             <span data-feather="file-text"></span> referrers (@item.Referers.Count)
                         </button>
                     </div>

--- a/src/Geta.NotFoundHandler.Admin/wwwroot/GetaNotFoundHandlerAdmin/js/dashboard.js
+++ b/src/Geta.NotFoundHandler.Admin/wwwroot/GetaNotFoundHandlerAdmin/js/dashboard.js
@@ -36,20 +36,18 @@
     }
 
     function adjustModalPosition() {
-        var modalTriggers = document.querySelectorAll('.modal-trigger');
+        var modalTriggers = document.querySelectorAll('.modal-trigger[data-bs-target]');
         modalTriggers.forEach(function (modalTrigger) {
-            modalTrigger.addEventListener('click',
-                function () {
-                    if (modalTrigger.dataset.bsTarget) {
-                        var modalDialog = document.querySelector(modalTrigger.dataset.bsTarget + " .modal-dialog");
-                        if (modalDialog) {
-                            modalDialog.style = "position: fixed;" +
-                                "top: " + modalTrigger.getBoundingClientRect().top + "px;" +
-                                "left: 50%;" +
-                                "transform: translate(-50%, -50%);";
-                        }
-                    }
-                });
+            modalTrigger.addEventListener('click', function () {
+                var modalDialog = document.querySelector(modalTrigger.dataset.bsTarget + " .modal-dialog");
+                if (!modalDialog) { return; }
+
+                modalDialog.style = "position: fixed;" +
+                    "top: " + modalTrigger.getBoundingClientRect().top + "px;" +
+                    "left: 50%;" +
+                    "min-width: 500px;" +
+                    "transform: translate(-50%, -50%);";
+            });
         });
     }
 

--- a/src/Geta.NotFoundHandler.Admin/wwwroot/GetaNotFoundHandlerAdmin/js/dashboard.js
+++ b/src/Geta.NotFoundHandler.Admin/wwwroot/GetaNotFoundHandlerAdmin/js/dashboard.js
@@ -1,16 +1,15 @@
 /* globals feather:false */
 
-(function() {
+(function () {
     'use strict';
 
     feather.replace();
 
-
     function clearInput() {
         var initiators = document.querySelectorAll('[data-clear]');
-        initiators.forEach(function(initiator) {
+        initiators.forEach(function (initiator) {
             initiator.addEventListener('click',
-                function(e) {
+                function (e) {
                     var target = e.currentTarget;
                     var selector = target.getAttribute('data-clear');
                     var input = document.querySelector(selector);
@@ -21,7 +20,7 @@
 
     function confirmSubmit() {
         var initiators = document.querySelectorAll('[data-confirm]');
-        initiators.forEach(function(initiator) {
+        initiators.forEach(function (initiator) {
             var form = initiator.form;
             form.addEventListener('submit',
                 function (e) {
@@ -36,6 +35,25 @@
         });
     }
 
+    function adjustModalPosition() {
+        var modalTriggers = document.querySelectorAll('.modal-trigger');
+        modalTriggers.forEach(function (modalTrigger) {
+            modalTrigger.addEventListener('click',
+                function () {
+                    if (modalTrigger.dataset.bsTarget) {
+                        var modalDialog = document.querySelector(modalTrigger.dataset.bsTarget + " .modal-dialog");
+                        if (modalDialog) {
+                            modalDialog.style = "position: fixed;" +
+                                "top: " + modalTrigger.getBoundingClientRect().top + "px;" +
+                                "left: 50%;" +
+                                "transform: translate(-50%, -50%);";
+                        }
+                    }
+                });
+        });
+    }
+
     clearInput();
     confirmSubmit();
+    adjustModalPosition();
 })()


### PR DESCRIPTION
Fixes #72 

Had to do a bit of a workaround since the table / modal is within an iframe so not easily fixed by only css.

Either way the modal is now positioned based on the offset height of the button which triggered it.

![image](https://user-images.githubusercontent.com/17863113/218068937-be242d05-4be4-45ee-8132-6351e6428b63.png)
