### PR TITLE
Ignore suggestions based on previously ignored

### DIFF
--- a/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
+++ b/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
@@ -70,7 +70,7 @@ namespace Geta.NotFoundHandler.Core.Suggestions
             var threshold = _configuration.ThreshHold;
             var start = logEvents.First().Requested;
             var end = logEvents.Last().Requested;
-            var diff = (end - start).TotalSeconds;
+            var diff = (int)Math.Floor((end - start).TotalSeconds);
 
             if ((diff != 0 && bufferSize / diff <= threshold)
                 || bufferSize == 0)

--- a/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
+++ b/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
@@ -53,11 +53,6 @@ namespace Geta.NotFoundHandler.Core.Suggestions
                 }
             }
 
-            EnqueueRequest(oldUrl, referer);
-        }
-
-        private static void EnqueueRequest(string oldUrl, string referer)
-        {
             LogQueue.Enqueue(new LogEvent(oldUrl, DateTime.UtcNow, referer));
         }
 

--- a/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
+++ b/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
@@ -20,6 +20,7 @@ namespace Geta.NotFoundHandler.Core.Suggestions
         private readonly ISuggestionRepository _suggestionRepository;
         private readonly IRedirectsService _redirectsService;
         private readonly NotFoundHandlerOptions _configuration;
+        private static object _lockObject = new object();
 
         public RequestLogger(
             IOptions<NotFoundHandlerOptions> options,
@@ -37,7 +38,7 @@ namespace Geta.NotFoundHandler.Core.Suggestions
         {
             if (AllowLogOfRequests())
             {
-                lock (LogQueue)
+                lock (_lockObject)
                 {
                     try
                     {

--- a/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
+++ b/src/Geta.NotFoundHandler/Core/Suggestions/RequestLogger.cs
@@ -20,7 +20,6 @@ namespace Geta.NotFoundHandler.Core.Suggestions
         private readonly ISuggestionRepository _suggestionRepository;
         private readonly IRedirectsService _redirectsService;
         private readonly NotFoundHandlerOptions _configuration;
-        private static object _lockObject = new object();
 
         public RequestLogger(
             IOptions<NotFoundHandlerOptions> options,
@@ -38,7 +37,7 @@ namespace Geta.NotFoundHandler.Core.Suggestions
         {
             if (AllowLogOfRequests())
             {
-                lock (_lockObject)
+                lock (LogQueue)
                 {
                     try
                     {


### PR DESCRIPTION
Fixes #37 

Now suggestions are not added if a matching ignore is found.

Also rewrote the buffering of 404 to allow logging if threshold has passed as well. Meaning the buffer can be less than buffersize before being processed. Seems logical to me but perhaps there's a reason for waiting to fill the buffersize always.