### PR TITLE
(feat) Added word break to tables

### DIFF
--- a/src/Geta.NotFoundHandler.Admin/wwwroot/GetaNotFoundHandlerAdmin/css/dashboard.css
+++ b/src/Geta.NotFoundHandler.Admin/wwwroot/GetaNotFoundHandlerAdmin/css/dashboard.css
@@ -114,3 +114,11 @@
 .input-file {
     width: 450px;
 }
+
+/*
+ * Table
+ */
+
+td {
+    word-break: break-all;
+}


### PR DESCRIPTION
Fixes a problem when the path becomes too long because of URL encoding non-Latin characters.

![geta-notfoundhandler](https://github.com/user-attachments/assets/4c3cf70c-72e2-432b-8417-1e1db46f6bc5)

![geta-notfoundhandler-2](https://github.com/user-attachments/assets/3f1a0d4b-a24f-43ee-9b00-34d465cfcea2)

#122 
