### PR TITLE
Add content URL history hash index

### DIFF
--- a/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
@@ -69,14 +69,14 @@ namespace Geta.NotFoundHandler.Optimizely.Data
 
         public IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved()
         {
-            var sqlCommand = $@"SELECT h.Id, h.ContentKey, h.Urls, h.CreatedUtc
+            var sqlCommand = $@"SELECT h.Id, h.ContentKey, h.Urls, h.CreatedUtc, h.md5_ContentKey
                                 FROM {ContentUrlHistoryTable} h
                                 INNER JOIN 
-                                    (SELECT ContentKey
+                                    (SELECT ContentKey, md5_ContentKey
                                     FROM {ContentUrlHistoryTable}
-                                    GROUP BY ContentKey
+                                    GROUP BY ContentKey, md5_ContentKey
                                     HAVING COUNT(*) > 1) k
-                                ON h.ContentKey = k.ContentKey
+                                ON h.ContentKey = k.ContentKey AND h.md5_ContentKey = k.md5_ContentKey
                                 ORDER BY h.ContentKey, h.CreatedUtc DESC";
 
             var dataTable = _dataExecutor.ExecuteQuery(sqlCommand);
@@ -90,7 +90,7 @@ namespace Geta.NotFoundHandler.Optimizely.Data
         {
             var contentKeyHash = CalculateMd5Hash(contentKey);
             
-            var sqlCommand = $@"SELECT h.Id, h.ContentKey, h.Urls, h.CreatedUtc 
+            var sqlCommand = $@"SELECT h.Id, h.ContentKey, h.Urls, h.CreatedUtc, h.md5_ContentKey
                                 FROM {ContentUrlHistoryTable} h
                                 INNER JOIN 
                                     (SELECT ContentKey
@@ -99,7 +99,7 @@ namespace Geta.NotFoundHandler.Optimizely.Data
                                     GROUP BY ContentKey
                                     HAVING COUNT(*) > 1) k
                                 ON h.ContentKey = k.ContentKey
-                                WHERE h.ContentKey = @contentKey AND md5_ContentKey = @contentKeyHash
+                                WHERE h.ContentKey = @contentKey AND h.md5_ContentKey = @contentKeyHash
                                 ORDER BY h.ContentKey, h.CreatedUtc DESC";
 
             var dataTable = _dataExecutor.ExecuteQuery(sqlCommand, 

--- a/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
@@ -38,7 +38,7 @@ namespace Geta.NotFoundHandler.Optimizely.Data
             }
         }
         
-        private byte[] CalculateMd5Hash(string input)
+        private static byte[] CalculateMd5Hash(string input)
         {
             using var md5 = MD5.Create();
             var inputBytes = Encoding.Unicode.GetBytes(input);

--- a/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
@@ -10,7 +10,7 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Configuration
 {
     public class OptimizelyNotFoundHandlerOptions
     {
-        public const int CurrentDbVersion = 1;
+        public const int CurrentDbVersion = 2;
 
         public bool AutomaticRedirectsEnabled { get; set; }
         public RedirectType AutomaticRedirectType { get; set; } = RedirectType.Temporary;

--- a/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Initialization/Upgrader.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Initialization/Upgrader.cs
@@ -125,9 +125,9 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Initialization
                 BEGIN TRANSACTION;
                 IF NOT EXISTS (
                     SELECT 1
-                    FROM INFORMATION_SCHEMA.COLUMNS
-                    WHERE TABLE_NAME = '{ContentUrlHistoryTable}' 
-                    AND COLUMN_NAME = 'md5_ContentKey'
+                    FROM sys.columns
+                    WHERE object_id = OBJECT_ID('{ContentUrlHistoryTable}')
+                    AND name = 'md5_ContentKey'
                 )
                 BEGIN
                     ALTER TABLE {ContentUrlHistoryTable} ADD md5_ContentKey AS HASHBYTES('MD5', [ContentKey]);

--- a/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Initialization/Upgrader.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Initialization/Upgrader.cs
@@ -2,7 +2,6 @@
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using Geta.NotFoundHandler.Data;
-using Geta.NotFoundHandler.Infrastructure.Configuration;
 using Geta.NotFoundHandler.Optimizely.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -50,9 +49,14 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Initialization
         /// </summary>
         private void Create()
         {
-            var created = CreateContentUrlHistoryTable();
+            var result = CreateContentUrlHistoryTable();
 
-            if (created)
+            if (result)
+            {
+                result = CreateContentKeyMd5Column();
+            }
+
+            if (result)
             {
                 CreateVersionNumberSp();
             }
@@ -76,14 +80,19 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Initialization
 
         private void Upgrade()
         {
-            UpdateVersionNumber();
+            var result = CreateContentKeyMd5Column();
+
+            if (result)
+            {
+                UpdateVersionNumber();
+            }
         }
 
         private void CreateVersionNumberSp()
         {
             _logger.LogInformation("Create Optimizely NotFoundHandler version SP START");
             var versionSp =
-                $@"CREATE PROCEDURE {VersionProcedure} AS RETURN {NotFoundHandlerOptions.CurrentDbVersion}";
+                $@"CREATE PROCEDURE {VersionProcedure} AS RETURN {OptimizelyNotFoundHandlerOptions.CurrentDbVersion}";
 
             var created = _dataExecutor.ExecuteNonQuery(versionSp);
 
@@ -105,8 +114,35 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Initialization
         private void UpdateVersionNumber()
         {
             var versionSp =
-                $@"ALTER PROCEDURE {VersionProcedure} AS RETURN {NotFoundHandlerOptions.CurrentDbVersion}";
+                $@"ALTER PROCEDURE {VersionProcedure} AS RETURN {OptimizelyNotFoundHandlerOptions.CurrentDbVersion}";
             _dataExecutor.ExecuteNonQuery(versionSp);
+        }
+
+        private bool CreateContentKeyMd5Column()
+        {
+            var command = $@"
+            BEGIN TRY
+                BEGIN TRANSACTION;
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM INFORMATION_SCHEMA.COLUMNS
+                    WHERE TABLE_NAME = '{ContentUrlHistoryTable}' 
+                    AND COLUMN_NAME = 'md5_ContentKey'
+                )
+                BEGIN
+                    ALTER TABLE {ContentUrlHistoryTable} ADD md5_ContentKey AS HASHBYTES('MD5', [ContentKey]);
+                    CREATE INDEX PContentKey_index ON {ContentUrlHistoryTable} (md5_ContentKey);
+                END
+
+                COMMIT TRANSACTION;
+            END TRY
+            BEGIN CATCH
+                ROLLBACK TRANSACTION;
+                THROW;
+            END CATCH;
+            ";
+
+            return _dataExecutor.ExecuteNonQuery(command);
         }
     }
 }

--- a/src/Geta.NotFoundHandler/Data/IDataExecutor.cs
+++ b/src/Geta.NotFoundHandler/Data/IDataExecutor.cs
@@ -20,5 +20,6 @@ namespace Geta.NotFoundHandler.Data
         DbParameter CreateIntParameter(string name, int value);
         DbParameter CreateBoolParameter(string name, bool value);
         DbParameter CreateDateTimeParameter(string name, DateTime value);
+        DbParameter CreateBinaryParameter(string name, byte[] value, int size = 8000);
     }
 }

--- a/src/Geta.NotFoundHandler/Data/SqlDataExecutor.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlDataExecutor.cs
@@ -183,6 +183,13 @@ namespace Geta.NotFoundHandler.Data
             return parameter;
         }
 
+        public DbParameter CreateBinaryParameter(string name, byte[] value, int size = 8000)
+        {
+            var parameter = CreateParameter(name, DbType.Binary, size);
+            parameter.Value = value;
+            return parameter;
+        }
+
         private static SqlParameter CreateReturnParameter()
         {
             var parameter = new SqlParameter


### PR DESCRIPTION
We identified a performance degradation in this query when the table has over 2 million records:

```
(@contentKey nvarchar(2000))SELECT TOP 1 Id, ContentKey, Urls, CreatedUtc 
                                FROM [dbo].[NotFoundHandler.ContentUrlHistory]
                                WHERE ContentKey = @contentKey
                                ORDER BY CreatedUtc DESC
```

To address this, we are adding an index on ContentKey using a new column that will store a hash of the ContentKey.

I ran some benchmarks, and as a result, we expect to improve performance by 10x with this approach when the table becomes large.

https://github.com/Geta/geta-notfoundhandler/issues/129