### PR TITLE
Bump up Optimizely db version to 3

### DIFF
--- a/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
@@ -10,7 +10,7 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Configuration
 {
     public class OptimizelyNotFoundHandlerOptions
     {
-        public const int CurrentDbVersion = 2;
+        public const int CurrentDbVersion = 3;
 
         public bool AutomaticRedirectsEnabled { get; set; }
         public RedirectType AutomaticRedirectType { get; set; } = RedirectType.Temporary;


### PR DESCRIPTION
Identified the problem that some projects already have a 2 version, which causes the database update to be skipped.
This is because previously was used version from the NotFoundHandlerOptions that is wrong for the Optimizely package.