### PR TITLE
Fix bug when new url is missing trailing slash

### DIFF
--- a/src/Geta.NotFoundHandler/Core/Redirects/CustomRedirectCollection.cs
+++ b/src/Geta.NotFoundHandler/Core/Redirects/CustomRedirectCollection.cs
@@ -222,7 +222,7 @@ public class CustomRedirectCollection : IEnumerable<CustomRedirect>
 
         builder.Append(path);
 
-        if (hasAppendSegment && !pathHasTrailingSlash)
+        if (hasAppendSegment && !path.EndsWith("/"))
         {
             builder.Append('/');
         }

--- a/tests/Geta.NotFoundHandler.Tests/CustomRedirectCollectionTests.cs
+++ b/tests/Geta.NotFoundHandler.Tests/CustomRedirectCollectionTests.cs
@@ -399,5 +399,24 @@ namespace Geta.NotFoundHandler.Tests
 
             Assert.Equal(expected, actual.NewUrl); 
         }
+        
+        /// <summary>
+        /// https://github.com/Geta/geta-notfoundhandler/issues/137
+        /// </summary>
+        [Fact]
+        public void Find_does_add_slash_when_new_url_is_missing_trailing_slash()
+        {
+            var collection = new CustomRedirectCollection
+            {
+                new CustomRedirect("/content", "/legacy"),
+            };
+
+            var urlToFind = "/content/file/";
+            var expected = "/legacy/file/";
+
+            var actual = collection.Find(urlToFind.ToUri());
+
+            Assert.Equal(expected, actual.NewUrl);
+        }
     }
 }


### PR DESCRIPTION
Steps to reproduce:
from -> /content
to -> /legacy

urlToFind = "/content/file/";
expected = "/legacy/file/";

Expected: /legacy/file/
Actual: /legacyfile/