### PR TITLE
Add support for redirects on 410 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ public void ConfigureServices(IServiceCollection services)
         o.IgnoredResourceExtensions = new[] { "jpg", "gif", "png", "css", "js", "ico", "swf", "woff" };
         o.Logging = LoggerMode.On;
         o.LogWithHostname = false;
+        o.Handle410 = false;
         o.AddProvider<NullNotFoundHandlerProvider>();
     });
 
@@ -150,6 +151,8 @@ Logging of 404 requests is buffered to shield your application from Denial of Se
 If the `bufferSize` is set to `0`, the `threshold` value will be ignored, and every request will be logged immediately.
 
 **LogWithHostname**: Set to `true` to include hostname in the log. Useful in a multisite environment with several hostnames/domains. Default is `false`
+
+**Handle410**: Set to `true` to handle redirect for expired pages in Optimizely.
 
 ### Specifying ignored resources
 

--- a/src/Geta.NotFoundHandler/Core/RequestHandler.cs
+++ b/src/Geta.NotFoundHandler/Core/RequestHandler.cs
@@ -44,9 +44,9 @@ namespace Geta.NotFoundHandler.Core
                 return;
             }
 
-            if (context.Response.StatusCode != 404)
+            if (context.Response.StatusCode != 404 && (_configuration.Handle410 && context.Response.StatusCode != 410))
             {
-                LogDebug("Not a 404 response.", context);
+                LogDebug("Not a 404 or 410 response.", context);
                 return;
             }
 

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
@@ -20,6 +20,7 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
         public bool UseInternalScheduler { get; set; }
         public string InternalSchedulerCronInterval { get; set; } = "0 0 * * *";
         public FileNotFoundMode HandlerMode { get; set; } = FileNotFoundMode.On;
+        public bool Handle410 { get; set; } = false;
         public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
 
         public string[] IgnoredResourceExtensions { get; set; } =


### PR DESCRIPTION
In Optimizely, expired pages respond with a 410 http response which is ignored by the NotFound Handler. 

This PR adds a option to enable the redirect manager to work on 410 responses. 