### PR TITLE
Optimize redirect collection

### DIFF
--- a/src/Geta.NotFoundHandler/Core/Redirects/CustomRedirectCollection.cs
+++ b/src/Geta.NotFoundHandler/Core/Redirects/CustomRedirectCollection.cs
@@ -19,7 +19,7 @@ public class CustomRedirectCollection : IEnumerable<CustomRedirect>
     private readonly IEnumerable<INotFoundHandler> _providers = new List<INotFoundHandler>();
 
     /// <summary>
-    /// Cache of URLs sorted ZA for look up of partially matched URLs
+    /// URLs sorted Z-A.
     /// </summary>
     private readonly SortedDictionary<string, CustomRedirect> _redirectsZA = new(new ReverseStringComparer());
 

--- a/src/Geta.NotFoundHandler/Core/Redirects/ReverseStringComparer.cs
+++ b/src/Geta.NotFoundHandler/Core/Redirects/ReverseStringComparer.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Geta Digital. All rights reserved.
+// Licensed under Apache-2.0. See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+
+namespace Geta.NotFoundHandler.Core.Redirects;
+
+/// <summary>
+/// A comparer that sorts strings in reverse order.
+/// </summary>
+public class ReverseStringComparer : IComparer<string>
+{
+    private readonly IComparer<string> _baseComparer;
+
+    public ReverseStringComparer() : this(StringComparer.OrdinalIgnoreCase) { }
+
+    public ReverseStringComparer(IComparer<string> baseComparer)
+    {
+        _baseComparer = baseComparer ?? throw new ArgumentNullException(nameof(baseComparer));
+    }
+
+    public int Compare(string x, string y)
+    {
+        return _baseComparer.Compare(y, x);
+    }
+}


### PR DESCRIPTION
Replaced the Dictionary for URL lookups with a SortedDictionary that sorts URLs in reverse order (Z-A). Removed the _quickLookupTable and updated methods to work with the new _redirectsZA structure. Added ReverseStringComparer class for custom string comparison.

Primary motivation for the change were frequent high CPU reports, whose .netperf files invariably pointed to CustomRedirectCollection.CreateSubSegmentRedirect as the hot path(~99% of Total CPU). Possibly related to issue #148.

All tests are passing.

![image](https://github.com/user-attachments/assets/8f7cee7f-2cba-44f4-802e-51e7ddf0deee)
