### PR TITLE
Add validation for Old and New URL in both the interface and CSV import

### DIFF
--- a/src/Geta.NotFoundHandler.Admin/Areas/GetaNotFoundHandlerAdmin/Pages/Models/RedirectModel.cs
+++ b/src/Geta.NotFoundHandler.Admin/Areas/GetaNotFoundHandlerAdmin/Pages/Models/RedirectModel.cs
@@ -1,17 +1,35 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Geta.NotFoundHandler.Core.Redirects;
 
 namespace Geta.NotFoundHandler.Admin.Pages.Geta.NotFoundHandler.Admin.Models
 {
-    public class RedirectModel
+    public class RedirectModel : IValidatableObject
     {
         public Guid? Id { get; set; }
+        
         [Required]
         public string OldUrl { get; set; }
+        
         [Required]
         public string NewUrl { get; set; }
+        
         public bool WildCardSkipAppend { get; set; }
+        
         public RedirectType RedirectType { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (!Uri.IsWellFormedUriString(OldUrl, UriKind.RelativeOrAbsolute))
+            {
+                yield return new ValidationResult("Old Url must be a valid absolute or relative url.", new[] { nameof(OldUrl) });
+            }
+
+            if (!Uri.IsWellFormedUriString(NewUrl, UriKind.RelativeOrAbsolute))
+            {
+                yield return new ValidationResult("New Url must be a valid absolute or relative url.", new[] { nameof(NewUrl) });
+            }
+        }
     }
 }

--- a/src/Geta.NotFoundHandler/Core/Redirects/RedirectsCsvParser.cs
+++ b/src/Geta.NotFoundHandler/Core/Redirects/RedirectsCsvParser.cs
@@ -46,6 +46,12 @@ public class RedirectsCsvParser : IRedirectsParser
 
         foreach (var item in csvImportModels)
         {
+            if (!IsValidRedirect(item))
+            {
+                _logger.LogWarning("NotFoundHandler: Skipping import of invalid redirect. OldUrl: {oldUrl}; NewUrl: {newUrl}", item.OldUrl, item.NewUrl);
+                continue;
+            }
+
             // Create new custom redirect nodes
             var redirectType = GetRedirectType(item.RedirectType);
             var skipWildCardAppend = GetSkipWildCardAppend(item.WildcardSkippedAppend);
@@ -54,6 +60,12 @@ public class RedirectsCsvParser : IRedirectsParser
         }
 
         return redirects;
+    }
+
+    private static bool IsValidRedirect(CsvImportModel model)
+    {
+        return Uri.IsWellFormedUriString(model.OldUrl, UriKind.RelativeOrAbsolute)
+            && Uri.IsWellFormedUriString(model.NewUrl, UriKind.RelativeOrAbsolute);
     }
 
     private static bool GetSkipWildCardAppend(string skipWildCardAttr)


### PR DESCRIPTION
See #174

Add validation to ensure Old Url and New Url are valid absolute or relative Uris
Updated the CSV import functionality to skip entries where either the Old or New Url is not a valid absolute or relative Uri.