### PR TITLE
Removes usage of BuildServiceProvider

### DIFF
--- a/src/Geta.NotFoundHandler/Core/ScheduledJobs/ServiceCollectionExtensions.cs
+++ b/src/Geta.NotFoundHandler/Core/ScheduledJobs/ServiceCollectionExtensions.cs
@@ -1,27 +1,37 @@
 ﻿// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
+using System;
 using Coravel;
 using Geta.NotFoundHandler.Core.ScheduledJobs.Suggestions;
 using Geta.NotFoundHandler.Infrastructure.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace Geta.NotFoundHandler.Core.ScheduledJobs;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection EnableScheduler(this IServiceCollection services)
+    [Obsolete("Use EnableScheduler with IConfigurationSection parameter instead.")]
+    public static IServiceCollection EnableScheduler(
+        this IServiceCollection services)
     {
-        using var serviceProvider = services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<NotFoundHandlerOptions>>().Value;
+        return services.EnableScheduler(null);
+    }
 
-        if (options.UseInternalScheduler)
+    public static IServiceCollection EnableScheduler(
+        this IServiceCollection services,
+        IConfigurationSection notFoundHandlerConfiguration)
+    {
+        var options = notFoundHandlerConfiguration?.Get<NotFoundHandlerOptions>();
+
+        if (!(options?.UseInternalScheduler ?? false))
         {
-            services.AddScheduler();
-        
-            services.AddTransient<SuggestionsCleanupJob>();
+            return services;
         }
+
+        services.AddScheduler();
+        services.AddTransient<SuggestionsCleanupJob>();
 
         return services;
     }

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/ConfigureNotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/ConfigureNotFoundHandlerOptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+
+namespace Geta.NotFoundHandler.Infrastructure.Configuration;
+
+public class ConfigureNotFoundHandlerOptions : IConfigureOptions<NotFoundHandlerOptions>
+{
+    private readonly Action<NotFoundHandlerOptions> _setupAction;
+
+    public ConfigureNotFoundHandlerOptions(Action<NotFoundHandlerOptions> setupAction)
+    {
+        _setupAction = setupAction;
+    }
+    
+    public void Configure(NotFoundHandlerOptions options)
+    {
+        _setupAction?.Invoke(options);
+    }
+}

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -20,17 +20,45 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
     {
         private static readonly Action<AuthorizationPolicyBuilder> DefaultPolicy = p => p.RequireRole("Administrators");
 
+        [Obsolete("Use AddNotFoundHandler(Action<NotFoundHandlerOptions>, IConfiguration) instead.")]
         public static IServiceCollection AddNotFoundHandler(
             this IServiceCollection services,
             Action<NotFoundHandlerOptions> setupAction)
         {
-            return AddNotFoundHandler(services, setupAction, DefaultPolicy);
+            return services.AddNotFoundHandler(setupAction, DefaultPolicy);
         }
 
         public static IServiceCollection AddNotFoundHandler(
             this IServiceCollection services,
             Action<NotFoundHandlerOptions> setupAction,
+            IConfiguration configuration)
+        {
+            return services.AddNotFoundHandlerInternal(setupAction, DefaultPolicy, configuration);
+        }
+
+        [Obsolete("Use AddNotFoundHandler(Action<NotFoundHandlerOptions>, Action<AuthorizationPolicyBuilder>, IConfiguration) instead.")]
+        public static IServiceCollection AddNotFoundHandler(
+            this IServiceCollection services,
+            Action<NotFoundHandlerOptions> setupAction,
             Action<AuthorizationPolicyBuilder> configurePolicy)
+        {
+            return AddNotFoundHandlerInternal(services, setupAction, configurePolicy);
+        }
+
+        public static IServiceCollection AddNotFoundHandler(
+            this IServiceCollection services,
+            Action<NotFoundHandlerOptions> setupAction,
+            Action<AuthorizationPolicyBuilder> configurePolicy,
+            IConfiguration configuration)
+        {
+            return AddNotFoundHandlerInternal(services, setupAction, configurePolicy, configuration);
+        }
+
+        private static IServiceCollection AddNotFoundHandlerInternal(
+            this IServiceCollection services,
+            Action<NotFoundHandlerOptions> setupAction,
+            Action<AuthorizationPolicyBuilder> configurePolicy,
+            IConfiguration configuration = null)
         {
             services.AddTransient<IDataExecutor, SqlDataExecutor>();
 
@@ -80,18 +108,25 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
                                                             x.GetRequiredService<IMemoryCache>()));
             services.AddTransient<IRegexRedirectsService, DefaultRegexRedirectsService>();
 
+            IConfigurationSection notFoundHandlerConfiguration = null;
+            
+            if (configuration != null)
+            {
+                notFoundHandlerConfiguration = configuration.GetSection(NotFoundHandlerOptions.Section);
+
+                services.Configure<NotFoundHandlerOptions>(notFoundHandlerConfiguration);
+            }
+
+            services
+                .AddTransient(_ => setupAction)
+                .ConfigureOptions<ConfigureNotFoundHandlerOptions>();
+
             var providerOptions = new NotFoundHandlerOptions();
             setupAction(providerOptions);
             foreach (var provider in providerOptions.Providers)
             {
                 services.AddTransient(typeof(INotFoundHandler), provider);
             }
-
-            services.AddOptions<NotFoundHandlerOptions>().Configure<IConfiguration>((options, configuration) =>
-            {
-                setupAction(options);
-                configuration.GetSection(NotFoundHandlerOptions.Section).Bind(options);
-            });
 
             services.AddAuthorization(options =>
             {
@@ -100,7 +135,7 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
 
             services.AddSingleton<ISuggestionsCleanupService, SuggestionsCleanupService>();
 
-            services.EnableScheduler();
+            services.EnableScheduler(notFoundHandlerConfiguration);
             
             return services;
         }


### PR DESCRIPTION
Resolves issues around settings not refreshing automatically with the Microsoft options pattern. Plus, is a code smell - Using BuildServiceProvider directly should not ever be done. 