### PR TITLE
Refactor middleware and removal of forced http 404

### DIFF
--- a/src/Geta.NotFoundHandler/Core/RequestHandler.cs
+++ b/src/Geta.NotFoundHandler/Core/RequestHandler.cs
@@ -95,18 +95,6 @@ namespace Geta.NotFoundHandler.Core
                 context
                     .Redirect(newUrl.NewUrl, newUrl.RedirectType);
             }
-            else if (canHandleRedirect && newUrl.State == (int)RedirectState.Deleted)
-            {
-                LogDebug("Handled deleted URL", context);
-
-                SetStatusCodeAndShow404(context, 410);
-            }
-            else
-            {
-                LogDebug("Not handled. Current URL is ignored or no redirect found.", context);
-
-                SetStatusCodeAndShow404(context);
-            }
 
             MarkHandled(context);
         }

--- a/src/Geta.NotFoundHandler/Core/RequestHandler.cs
+++ b/src/Geta.NotFoundHandler/Core/RequestHandler.cs
@@ -7,6 +7,7 @@ using Geta.NotFoundHandler.Core.Redirects;
 using Geta.NotFoundHandler.Core.Suggestions;
 using Geta.NotFoundHandler.Infrastructure.Configuration;
 using Geta.NotFoundHandler.Infrastructure.Web;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Logging;
@@ -69,7 +70,24 @@ namespace Geta.NotFoundHandler.Core
 
             LogDebug("Handling 404 request.", context);
 
-            var notFoundUri = new Uri(context.Request.GetDisplayUrl());
+            Uri notFoundUri;
+
+            if (context.Features.Get<IStatusCodeReExecuteFeature>() is StatusCodeReExecuteFeature statusCodeReExecuteFeature)
+            {
+                var request = context.Request;
+                var absoluteUrl = $"{request.Scheme}://{request.Host}{statusCodeReExecuteFeature.OriginalPathBase}{statusCodeReExecuteFeature.OriginalPath}{statusCodeReExecuteFeature.OriginalQueryString}";
+    
+                if (!Uri.TryCreate(absoluteUrl, UriKind.Absolute, out notFoundUri))
+                {
+                    // Fallback to current request URL if construction fails
+                    notFoundUri = new Uri(context.Request.GetDisplayUrl());
+                }
+            }
+            else
+            {
+                notFoundUri = new Uri(context.Request.GetDisplayUrl());
+            }
+
 
             if (IsResourceFile(notFoundUri))
             {

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
             services.AddSingleton<IRedirectHandler, CustomRedirectHandler>(s => s.GetRequiredService<CustomRedirectHandler>());
             services.AddSingleton<RedirectsEvents>();
             services.AddTransient<RequestHandler>();
+            services.AddTransient<NotFoundHandlerMiddleware>();
 
             services.AddSingleton<Func<IRedirectsService>>(x => x.GetService<IRedirectsService>);
             services.AddTransient<IRedirectsService, DefaultRedirectsService>();

--- a/src/Geta.NotFoundHandler/Infrastructure/Initialization/NotFoundHandlerMiddleware.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Initialization/NotFoundHandlerMiddleware.cs
@@ -7,24 +7,24 @@ using Microsoft.AspNetCore.Http;
 
 namespace Geta.NotFoundHandler.Infrastructure.Initialization
 {
-    public class NotFoundHandlerMiddleware
+    public class NotFoundHandlerMiddleware : IMiddleware
     {
-        private readonly RequestDelegate _next;
+        private readonly RequestHandler _requestHandler;
 
-        public NotFoundHandlerMiddleware(RequestDelegate next)
+        public NotFoundHandlerMiddleware(RequestHandler requestHandler)
         {
-            _next = next;
+            _requestHandler = requestHandler;
         }
 
-        public async Task InvokeAsync(HttpContext context, RequestHandler requestHandler)
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
-            await _next(context);
-            
-            context.Response.OnStarting(() =>
+            context.Response.OnStarting(state =>
             {
-                requestHandler.Handle(context);
+                _requestHandler.Handle((HttpContext)state);
                 return Task.CompletedTask;
-            });
+            }, context);
+
+            await next(context);
         }
     }
 }

--- a/src/Geta.NotFoundHandler/Infrastructure/Initialization/NotFoundHandlerMiddleware.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Initialization/NotFoundHandlerMiddleware.cs
@@ -19,8 +19,12 @@ namespace Geta.NotFoundHandler.Infrastructure.Initialization
         public async Task InvokeAsync(HttpContext context, RequestHandler requestHandler)
         {
             await _next(context);
-
-            requestHandler.Handle(context);
+            
+            context.Response.OnStarting(() =>
+            {
+                requestHandler.Handle(context);
+                return Task.CompletedTask;
+            });
         }
     }
 }


### PR DESCRIPTION
Refactor NotFoundHandlerMiddleware to use IMiddleware and streamline response handling. 

Removed condition for forced http 404, causing issues when using an active status code of HTTP 200.

---

Enhance RequestHandler to correctly handle 404 URIs during status code re-execution. Added logic to construct the not found URI from original request details when available.
