### PR TITLE
Page the "Register content move redirects" job so it survives large tables (6.x backport of #188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `OptimizelyNotFoundHandlerOptions.MovedContentBatchSize` (default 1000) and `NotFoundHandlerOptions.CommandTimeout` so the "Register content move redirects" job pages through large `NotFoundHandler.ContentUrlHistory` tables instead of loading every row in one unbounded query that exceeded the command timeout.
+- `IContentUrlHistoryLoader.GetAllMoved(int skip, int take)` for paged access to moved content. Ships as a default interface implementation (pages in-memory over `GetAllMoved()`), so existing implementers keep compiling.
+
+### Changed
+
+- `SqlDataExecutor.ExecuteQuery` now propagates SQL exceptions (e.g. command timeouts) instead of swallowing them and returning an empty result, which previously surfaced as a misleading "Cannot find table 0" error.
+
 ## [1.1.0]
 
 - Refctoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [6.1.0]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ If the `bufferSize` is set to `0`, the `threshold` value will be ignored, and ev
 
 **LogWithHostname**: Set to `true` to include hostname in the log. Useful in a multisite environment with several hostnames/domains. Default is `false`
 
+**CommandTimeout**: Command timeout, in seconds, applied to SQL queries issued by the NotFound handler. Raise it past the SqlClient default of 30 if you have very large NotFound handler tables. Default is 30
+
 **ActiveStatusCodes**: A integerlist with the status codes that NotFoundHandler will be active on. (Ex. ```options.ActiveStatusCodes = new int[] { StatusCodes.Status404NotFound, StatusCodes.Status410Gone };```)
 
 ### Specifying ignored resources
@@ -320,7 +322,13 @@ An Optimizely scheduled job was added - <code>[Geta NotFoundHandler] Suggestions
 
 Additionally, there are two optimizely scheduled jobs responsible for:
 - *[Geta NotFoundHandler] Index content URLs* - as mentioned before, this job indexes URLs of content. Usually, it is required to run this job only once. All new content is automatically indexed. But if for some reason content publish events are not firing when creating new content (for example, during the import), then you should set this job to run frequently.
-- *[Geta NotFoundHandler] Register content move redirects* - this job creates redirects based on registered moved content. Normally, this job is not required at all, but there might be situations when content move is registered but redirect creation is not completed. This could happen during deployments. In this case, you can manually run this job or schedule it to run time to time to fix such issues.
+- *[Geta NotFoundHandler] Register content move redirects* - this job creates redirects based on registered moved content. Normally, this job is not required at all, but there might be situations when content move is registered but redirect creation is not completed. This could happen during deployments. In this case, you can manually run this job or schedule it to run time to time to fix such issues. The job processes the `NotFoundHandler.ContentUrlHistory` table page-by-page so it scales to large tables. You can tune the page size via `MovedContentBatchSize` (default 1000):
+```
+services.AddOptimizelyNotFoundHandler(o =>
+{
+    o.MovedContentBatchSize = 1000;
+});
+```
 
 
 # Troubleshooting

--- a/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/IContentUrlHistoryLoader.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/IContentUrlHistoryLoader.cs
@@ -9,6 +9,16 @@ namespace Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects
     {
         bool IsRegistered(ContentUrlHistory entity);
         IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved();
+
+        /// <summary>
+        /// Returns a single page of moved content (keys with more than one URL-history entry),
+        /// ordered by content key. Lets callers stream large tables instead of loading every row
+        /// in one unbounded query.
+        /// </summary>
+        /// <param name="skip">Number of moved content keys to skip.</param>
+        /// <param name="take">Maximum number of moved content keys to return.</param>
+        IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved(int skip, int take);
+
         IReadOnlyCollection<ContentUrlHistory> GetMoved(string contentKey);
     }
 }

--- a/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/IContentUrlHistoryLoader.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/IContentUrlHistoryLoader.cs
@@ -2,6 +2,7 @@
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects
 {
@@ -17,7 +18,12 @@ namespace Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects
         /// </summary>
         /// <param name="skip">Number of moved content keys to skip.</param>
         /// <param name="take">Maximum number of moved content keys to return.</param>
-        IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved(int skip, int take);
+        /// <remarks>
+        /// Default implementation pages in-memory over <see cref="GetAllMoved()"/> so existing
+        /// implementers keep compiling; data-backed stores should override it with a server-side paged query.
+        /// </remarks>
+        IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved(int skip, int take)
+            => GetAllMoved().Skip(skip).Take(take);
 
         IReadOnlyCollection<ContentUrlHistory> GetMoved(string contentKey);
     }

--- a/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/RegisterMovedContentRedirectsJob.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/RegisterMovedContentRedirectsJob.cs
@@ -29,7 +29,8 @@ namespace Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects
         {
             _automaticRedirectsService = automaticRedirectsService;
             _contentUrlHistoryLoader = contentUrlHistoryLoader;
-            _batchSize = options.Value.MovedContentBatchSize;
+            // Clamp to >= 1: a misconfigured 0/negative would page with FETCH NEXT 0 ROWS (invalid SQL) and fail the job.
+            _batchSize = Math.Max(1, options.Value.MovedContentBatchSize);
             _jobStatusLogger = new JobStatusLogger(OnStatusChanged);
 
             IsStoppable = true;

--- a/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/RegisterMovedContentRedirectsJob.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Core/AutomaticRedirects/RegisterMovedContentRedirectsJob.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using EPiServer.PlugIn;
 using EPiServer.Scheduler;
 using Geta.NotFoundHandler.Optimizely.Infrastructure;
+using Geta.NotFoundHandler.Optimizely.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects
 {
@@ -17,14 +19,17 @@ namespace Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects
         private readonly IContentUrlHistoryLoader _contentUrlHistoryLoader;
         private readonly JobStatusLogger _jobStatusLogger;
         private readonly IAutomaticRedirectsService _automaticRedirectsService;
+        private readonly int _batchSize;
         private bool _stopped;
 
         public RegisterMovedContentRedirectsJob(
             IAutomaticRedirectsService automaticRedirectsService,
-            IContentUrlHistoryLoader contentUrlHistoryLoader)
+            IContentUrlHistoryLoader contentUrlHistoryLoader,
+            IOptions<OptimizelyNotFoundHandlerOptions> options)
         {
             _automaticRedirectsService = automaticRedirectsService;
             _contentUrlHistoryLoader = contentUrlHistoryLoader;
+            _batchSize = options.Value.MovedContentBatchSize;
             _jobStatusLogger = new JobStatusLogger(OnStatusChanged);
 
             IsStoppable = true;
@@ -32,45 +37,59 @@ namespace Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects
 
         public override string Execute()
         {
-            var movedContent = _contentUrlHistoryLoader.GetAllMoved().ToList();
-            var totalCount = movedContent.Count;
             var successCount = 0;
             var failedCount = 0;
             var currentCount = 0;
+            var skip = 0;
 
-            _jobStatusLogger.LogWithStatus($"In total will process moved content: {totalCount}");
+            _jobStatusLogger.LogWithStatus($"Processing moved content in batches of {_batchSize}");
 
-            foreach (var content in movedContent)
+            // Page through the moved content rather than materialising the whole table up front.
+            // CreateRedirects only touches the redirects store, not ContentUrlHistory, so the moved
+            // set is stable for the duration of the run and skip-based paging never skips a key.
+            while (true)
             {
-                if (_stopped)
+                var batch = _contentUrlHistoryLoader.GetAllMoved(skip, _batchSize).ToList();
+
+                foreach (var content in batch)
                 {
-                    _jobStatusLogger.Log(
-                        $"Job was stopped, successful content handled before stopped: {successCount} out of total {totalCount} content");
-                    return _jobStatusLogger.ToString();
+                    if (_stopped)
+                    {
+                        _jobStatusLogger.Log(
+                            $"Job was stopped, successful content handled before stopped: {successCount} out of {currentCount} processed");
+                        return _jobStatusLogger.ToString();
+                    }
+
+                    currentCount++;
+
+                    try
+                    {
+                        _automaticRedirectsService.CreateRedirects(content.histories);
+                        successCount++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jobStatusLogger.Log($"Processing [{content.contentKey}] failed, exception: {ex}");
+                        failedCount++;
+                    }
+
+                    if (currentCount % 500 == 0)
+                    {
+                        _jobStatusLogger.Status(
+                            $"Processed {currentCount}, of whom successful {successCount}; failed: {failedCount}");
+                    }
                 }
 
-                currentCount++;
-
-                try
+                if (batch.Count < _batchSize)
                 {
-                    _automaticRedirectsService.CreateRedirects(content.histories);
-                    successCount++;
-                }
-                catch (Exception ex)
-                {
-                    _jobStatusLogger.Log($"Processing [{content.contentKey}] failed, exception: {ex}");
-                    failedCount++;
+                    break;
                 }
 
-                if (currentCount % 500 == 0)
-                {
-                    _jobStatusLogger.Status(
-                        $"Processed {currentCount} of whom successful {successCount} out of total {totalCount} content; failed: {failedCount}");
-                }
+                skip += _batchSize;
             }
 
             _jobStatusLogger.Log(
-                $"Processed {currentCount} of whom successful {successCount} out of total {totalCount} content; failed: {failedCount}");
+                $"Processed {currentCount}, of whom successful {successCount}; failed: {failedCount}");
 
             return _jobStatusLogger.ToString();
         }

--- a/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
@@ -18,6 +18,7 @@ namespace Geta.NotFoundHandler.Optimizely.Data
     {
         private const string ContentUrlHistoryTable = "[dbo].[NotFoundHandler.ContentUrlHistory]";
         private const string AllFields = "Id, ContentKey, Urls, CreatedUtc, md5_ContentKey";
+        private const int DefaultPageSize = 1000;
         private readonly IDataExecutor _dataExecutor;
 
         public SqlContentUrlHistoryRepository(IDataExecutor dataExecutor)
@@ -69,17 +70,47 @@ namespace Geta.NotFoundHandler.Optimizely.Data
 
         public IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved()
         {
+            // Stream the table one page at a time rather than issuing a single unbounded query that
+            // grows with the table and can exceed the command timeout on large sites.
+            var skip = 0;
+            while (true)
+            {
+                var page = GetAllMoved(skip, DefaultPageSize).ToList();
+
+                foreach (var moved in page)
+                {
+                    yield return moved;
+                }
+
+                if (page.Count < DefaultPageSize)
+                {
+                    yield break;
+                }
+
+                skip += DefaultPageSize;
+            }
+        }
+
+        public IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved(int skip, int take)
+        {
+            // Page over the moved content keys (md5_ContentKey is the hash of ContentKey, so each key
+            // maps to a single group and is never split across pages) and return their histories.
             var sqlCommand = $@"SELECT h.Id, h.ContentKey, h.Urls, h.CreatedUtc, h.md5_ContentKey
                                 FROM {ContentUrlHistoryTable} h
-                                INNER JOIN 
+                                INNER JOIN
                                     (SELECT ContentKey, md5_ContentKey
                                     FROM {ContentUrlHistoryTable}
                                     GROUP BY ContentKey, md5_ContentKey
-                                    HAVING COUNT(*) > 1) k
+                                    HAVING COUNT(*) > 1
+                                    ORDER BY ContentKey, md5_ContentKey
+                                    OFFSET @skip ROWS FETCH NEXT @take ROWS ONLY) k
                                 ON h.ContentKey = k.ContentKey AND h.md5_ContentKey = k.md5_ContentKey
                                 ORDER BY h.ContentKey, h.CreatedUtc DESC";
 
-            var dataTable = _dataExecutor.ExecuteQuery(sqlCommand);
+            var dataTable = _dataExecutor.ExecuteQuery(
+                sqlCommand,
+                _dataExecutor.CreateIntParameter("skip", skip),
+                _dataExecutor.CreateIntParameter("take", take));
 
             var histories = ToContentUrlHistory(dataTable);
 

--- a/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Data/SqlContentUrlHistoryRepository.cs
@@ -93,6 +93,15 @@ namespace Geta.NotFoundHandler.Optimizely.Data
 
         public IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> GetAllMoved(int skip, int take)
         {
+            // Guard the inputs: "FETCH NEXT 0 ROWS ONLY" (or a negative count) is invalid SQL, and a
+            // negative offset would fail too, so a bad caller shouldn't reach the database.
+            if (take <= 0)
+            {
+                return Enumerable.Empty<(string, IReadOnlyCollection<ContentUrlHistory>)>();
+            }
+
+            skip = Math.Max(0, skip);
+
             // Page over the moved content keys (md5_ContentKey is the hash of ContentKey, so each key
             // maps to a single group and is never split across pages) and return their histories.
             var sqlCommand = $@"SELECT h.Id, h.ContentKey, h.Urls, h.CreatedUtc, h.md5_ContentKey

--- a/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler.Optimizely/Infrastructure/Configuration/OptimizelyNotFoundHandlerOptions.cs
@@ -16,6 +16,12 @@ namespace Geta.NotFoundHandler.Optimizely.Infrastructure.Configuration
         public bool AutomaticRedirectsEnabled { get; set; }
         public RedirectType AutomaticRedirectType { get; set; } = RedirectType.Temporary;
 
+        /// <summary>
+        /// Number of moved content keys the "Register content move redirects" job loads per page.
+        /// The job processes the table page-by-page so it scales to large NotFoundHandler tables.
+        /// </summary>
+        public int MovedContentBatchSize { get; set; } = 1000;
+
         private readonly List<Type> _contentKeyProviders = new();
         public IEnumerable<Type> ContentKeyProviders => _contentKeyProviders;
 

--- a/src/Geta.NotFoundHandler/Data/SqlDataExecutor.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlDataExecutor.cs
@@ -23,7 +23,8 @@ namespace Geta.NotFoundHandler.Data
             ILogger<SqlDataExecutor> logger)
         {
             _connectionString = options.Value.ConnectionString;
-            _commandTimeout = options.Value.CommandTimeout;
+            // SqlCommand.CommandTimeout throws on a negative value; clamp so a misconfiguration can't break every query. (0 = no timeout.)
+            _commandTimeout = Math.Max(0, options.Value.CommandTimeout);
             _logger = logger;
         }
 

--- a/src/Geta.NotFoundHandler/Data/SqlDataExecutor.cs
+++ b/src/Geta.NotFoundHandler/Data/SqlDataExecutor.cs
@@ -16,12 +16,14 @@ namespace Geta.NotFoundHandler.Data
     {
         private readonly ILogger<SqlDataExecutor> _logger;
         private readonly string _connectionString;
+        private readonly int _commandTimeout;
 
         public SqlDataExecutor(
             IOptions<NotFoundHandlerOptions> options,
             ILogger<SqlDataExecutor> logger)
         {
             _connectionString = options.Value.ConnectionString;
+            _commandTimeout = options.Value.CommandTimeout;
             _logger = logger;
         }
 
@@ -42,6 +44,12 @@ namespace Geta.NotFoundHandler.Data
                 _logger.LogError(ex,
                                  "An error occurred in the ExecuteSQL method with the following sql: {SqlCommand}",
                                  sqlCommand);
+
+                // Previously the exception was swallowed here and execution fell through to
+                // 'return ds.Tables[0]'. On a failed Fill the DataSet has no tables, so that line
+                // threw IndexOutOfRangeException ("Cannot find table 0"), masking the real cause
+                // (e.g. a command timeout). Rethrow so callers see the actual failure.
+                throw;
             }
 
             return ds.Tables[0];
@@ -199,10 +207,11 @@ namespace Geta.NotFoundHandler.Data
             return parameter;
         }
 
-        private static SqlCommand CreateCommand(SqlConnection connection, string sqlCommand, params IDbDataParameter[] parameters)
+        private SqlCommand CreateCommand(SqlConnection connection, string sqlCommand, params IDbDataParameter[] parameters)
         {
             var command = connection.CreateCommand();
             command.CommandText = sqlCommand;
+            command.CommandTimeout = _commandTimeout;
 
             if (parameters != null)
             {

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
@@ -21,6 +21,7 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
         /// <summary>
         /// Command timeout, in seconds, applied to SQL queries issued by <see cref="Data.SqlDataExecutor"/>.
         /// Exposed so sites with large NotFoundHandler tables can raise it past the SqlClient default of 30s.
+        /// Set to 0 for no timeout; negative values are treated as 0.
         /// </summary>
         public int CommandTimeout { get; set; } = 30;
         public SuggestionsCleanupOptions SuggestionsCleanupOptions { get; set; } = new();

--- a/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
+++ b/src/Geta.NotFoundHandler/Infrastructure/Configuration/NotFoundHandlerOptions.cs
@@ -17,6 +17,12 @@ namespace Geta.NotFoundHandler.Infrastructure.Configuration
 
         public int BufferSize { get; set; } = 30;
         public int ThreshHold { get; set; } = 5;
+
+        /// <summary>
+        /// Command timeout, in seconds, applied to SQL queries issued by <see cref="Data.SqlDataExecutor"/>.
+        /// Exposed so sites with large NotFoundHandler tables can raise it past the SqlClient default of 30s.
+        /// </summary>
+        public int CommandTimeout { get; set; } = 30;
         public SuggestionsCleanupOptions SuggestionsCleanupOptions { get; set; } = new();
         public bool UseInternalScheduler { get; set; }
         public string InternalSchedulerCronInterval { get; set; } = "0 0 * * *";

--- a/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/RegisterMovedContentRedirectsJobTests.cs
+++ b/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/RegisterMovedContentRedirectsJobTests.cs
@@ -40,6 +40,33 @@ public class RegisterMovedContentRedirectsJobTests
     }
 
     [Fact]
+    public void Execute_stops_after_empty_page_when_total_is_exact_multiple_of_batch_size()
+    {
+        A.CallTo(() => _loader.GetAllMoved(0, 2)).Returns(Moved("a", "b"));
+        A.CallTo(() => _loader.GetAllMoved(2, 2)).Returns(Moved()); // full last page forces one extra, empty fetch
+        var job = CreateJob(batchSize: 2);
+
+        job.Execute();
+
+        A.CallTo(() => _loader.GetAllMoved(2, 2)).MustHaveHappened();
+        A.CallTo(() => _loader.GetAllMoved(4, 2)).MustNotHaveHappened();
+        A.CallTo(() => _redirectsService.CreateRedirects(A<IReadOnlyCollection<ContentUrlHistory>>._))
+            .MustHaveHappened(2, Times.Exactly);
+    }
+
+    [Fact]
+    public void Execute_clamps_non_positive_batch_size_to_one()
+    {
+        var job = CreateJob(batchSize: 0);
+
+        job.Execute();
+
+        // A configured 0/negative would page with "FETCH NEXT 0 ROWS ONLY" (invalid SQL); the page size must clamp to >= 1.
+        A.CallTo(() => _loader.GetAllMoved(0, 0)).MustNotHaveHappened();
+        A.CallTo(() => _loader.GetAllMoved(0, 1)).MustHaveHappened();
+    }
+
+    [Fact]
     public void Execute_continues_when_a_single_item_fails()
     {
         A.CallTo(() => _loader.GetAllMoved(0, 10)).Returns(Moved("good", "bad", "good"));

--- a/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/RegisterMovedContentRedirectsJobTests.cs
+++ b/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/RegisterMovedContentRedirectsJobTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using Geta.NotFoundHandler.Optimizely.Core.AutomaticRedirects;
+using Geta.NotFoundHandler.Optimizely.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Geta.NotFoundHandler.Optimizely.Tests.AutomaticRedirects;
+
+public class RegisterMovedContentRedirectsJobTests
+{
+    private readonly IAutomaticRedirectsService _redirectsService = A.Fake<IAutomaticRedirectsService>();
+    private readonly IContentUrlHistoryLoader _loader = A.Fake<IContentUrlHistoryLoader>();
+
+    [Fact]
+    public void Execute_processes_every_page()
+    {
+        A.CallTo(() => _loader.GetAllMoved(0, 2)).Returns(Moved("a", "b"));
+        A.CallTo(() => _loader.GetAllMoved(2, 2)).Returns(Moved("c"));
+        var job = CreateJob(batchSize: 2);
+
+        job.Execute();
+
+        A.CallTo(() => _redirectsService.CreateRedirects(A<IReadOnlyCollection<ContentUrlHistory>>._))
+            .MustHaveHappened(3, Times.Exactly);
+        A.CallTo(() => _loader.GetAllMoved(0, 2)).MustHaveHappened();
+        A.CallTo(() => _loader.GetAllMoved(2, 2)).MustHaveHappened();
+    }
+
+    [Fact]
+    public void Execute_does_not_request_next_page_after_a_partial_page()
+    {
+        A.CallTo(() => _loader.GetAllMoved(0, 5)).Returns(Moved("a", "b"));
+        var job = CreateJob(batchSize: 5);
+
+        job.Execute();
+
+        A.CallTo(() => _loader.GetAllMoved(5, 5)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public void Execute_continues_when_a_single_item_fails()
+    {
+        A.CallTo(() => _loader.GetAllMoved(0, 10)).Returns(Moved("good", "bad", "good"));
+        A.CallTo(() => _redirectsService.CreateRedirects(A<IReadOnlyCollection<ContentUrlHistory>>.That.Matches(
+                x => x.Count == 1 && x.First().ContentKey == "bad")))
+            .Throws(new System.InvalidOperationException("boom"));
+        var job = CreateJob(batchSize: 10);
+
+        var result = job.Execute();
+
+        // All three are attempted even though the middle one throws.
+        A.CallTo(() => _redirectsService.CreateRedirects(A<IReadOnlyCollection<ContentUrlHistory>>._))
+            .MustHaveHappened(3, Times.Exactly);
+        Assert.Contains("failed", result);
+    }
+
+    private RegisterMovedContentRedirectsJob CreateJob(int batchSize)
+    {
+        var options = Options.Create(new OptimizelyNotFoundHandlerOptions { MovedContentBatchSize = batchSize });
+        return new RegisterMovedContentRedirectsJob(_redirectsService, _loader, options);
+    }
+
+    private static IEnumerable<(string contentKey, IReadOnlyCollection<ContentUrlHistory> histories)> Moved(params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            yield return (key, new List<ContentUrlHistory> { new() { ContentKey = key } });
+        }
+    }
+}

--- a/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/SqlContentUrlHistoryRepositoryTests.cs
+++ b/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/SqlContentUrlHistoryRepositoryTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Data;
+using System.Linq;
+using FakeItEasy;
+using Geta.NotFoundHandler.Data;
+using Geta.NotFoundHandler.Optimizely.Data;
+using Xunit;
+
+namespace Geta.NotFoundHandler.Optimizely.Tests.AutomaticRedirects;
+
+public class SqlContentUrlHistoryRepositoryTests
+{
+    private readonly IDataExecutor _dataExecutor = A.Fake<IDataExecutor>();
+    private readonly SqlContentUrlHistoryRepository _repository;
+
+    public SqlContentUrlHistoryRepositoryTests()
+    {
+        _repository = new SqlContentUrlHistoryRepository(_dataExecutor);
+    }
+
+    [Fact]
+    public void GetAllMoved_paged_passes_skip_and_take()
+    {
+        A.CallTo(() => _dataExecutor.ExecuteQuery(A<string>._, A<IDbDataParameter[]>._)).Returns(EmptyTable());
+
+        _ = _repository.GetAllMoved(40, 20).ToList();
+
+        A.CallTo(() => _dataExecutor.CreateIntParameter("skip", 40)).MustHaveHappened();
+        A.CallTo(() => _dataExecutor.CreateIntParameter("take", 20)).MustHaveHappened();
+    }
+
+    [Fact]
+    public void GetAllMoved_paged_groups_histories_by_content_key()
+    {
+        var table = EmptyTable();
+        AddRow(table, "key-a");
+        AddRow(table, "key-a");
+        AddRow(table, "key-b");
+        A.CallTo(() => _dataExecutor.ExecuteQuery(A<string>._, A<IDbDataParameter[]>._)).Returns(table);
+
+        var result = _repository.GetAllMoved(0, 1000).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, result.Single(x => x.contentKey == "key-a").histories.Count);
+        Assert.Equal(1, result.Single(x => x.contentKey == "key-b").histories.Count);
+    }
+
+    [Fact]
+    public void GetAllMoved_stops_paging_when_page_is_not_full()
+    {
+        var shortPage = EmptyTable();
+        AddRow(shortPage, "only-key");
+        A.CallTo(() => _dataExecutor.ExecuteQuery(A<string>._, A<IDbDataParameter[]>._)).Returns(shortPage);
+
+        _ = _repository.GetAllMoved().ToList();
+
+        // The first page returns fewer rows than the page size, so no further query is issued.
+        A.CallTo(() => _dataExecutor.ExecuteQuery(A<string>._, A<IDbDataParameter[]>._)).MustHaveHappenedOnceExactly();
+    }
+
+    private static DataTable EmptyTable()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(Guid));
+        table.Columns.Add("ContentKey", typeof(string));
+        table.Columns.Add("Urls", typeof(string));
+        table.Columns.Add("CreatedUtc", typeof(DateTime));
+        return table;
+    }
+
+    private static void AddRow(DataTable table, string contentKey)
+    {
+        table.Rows.Add(Guid.NewGuid(), contentKey, string.Empty, DateTime.UtcNow);
+    }
+}

--- a/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/SqlContentUrlHistoryRepositoryTests.cs
+++ b/tests/Geta.NotFoundHandler.Optimizely.Tests/AutomaticRedirects/SqlContentUrlHistoryRepositoryTests.cs
@@ -42,7 +42,19 @@ public class SqlContentUrlHistoryRepositoryTests
 
         Assert.Equal(2, result.Count);
         Assert.Equal(2, result.Single(x => x.contentKey == "key-a").histories.Count);
-        Assert.Equal(1, result.Single(x => x.contentKey == "key-b").histories.Count);
+        Assert.Single(result.Single(x => x.contentKey == "key-b").histories);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void GetAllMoved_paged_returns_empty_without_querying_when_take_is_not_positive(int take)
+    {
+        var result = _repository.GetAllMoved(0, take).ToList();
+
+        Assert.Empty(result);
+        // "FETCH NEXT 0 ROWS ONLY" (or a negative count) is invalid SQL, so no query should be issued.
+        A.CallTo(() => _dataExecutor.ExecuteQuery(A<string>._, A<IDbDataParameter[]>._)).MustNotHaveHappened();
     }
 
     [Fact]


### PR DESCRIPTION
## Backport of #188 to the CMS 12 / .NET 8 line

This is the `release/v6` backport of #188 ("Page the 'Register content move redirects' job so it survives large tables"), which was merged into `master` and released as **v7.1.0** (CMS 13 / .NET 10). Per @valdisiljuconoks's request on #188 to open a PR against the CMS 12 line, this targets the new `release/v6` branch. The code change is identical to what shipped in 7.1.0 — the src files merged clean across the CMS 13 rebase, so this is the same diff applied on top of `v6.0.0`, built and tested on **.NET 8**. Only the CHANGELOG lineage differs (6.x, no 7.0.0 entry).

## Problem

The **[Geta NotFoundHandler] Register content move redirects** job loads the entire `NotFoundHandler.ContentUrlHistory` table in a single unbounded query before doing any work:

```csharp
var movedContent = _contentUrlHistoryLoader.GetAllMoved().ToList();
```

`GetAllMoved()` issues a self-join + `GROUP BY ... HAVING COUNT(*) > 1` over the whole table with no paging. On sites with a large history table this `SELECT` exceeds the SqlClient command timeout (the default 30s, which was never overridden). `SqlDataExecutor.ExecuteQuery` then **catches and swallows** the timeout, logs it, and falls through to `return ds.Tables[0]` — but on a failed `Fill` the `DataSet` has no tables, so that line throws `IndexOutOfRangeException: "Cannot find table 0"`. The operator sees a confusing "Cannot find table 0" with no hint that the real cause is a query timeout, and the job never completes.

## Fix

- **`SqlDataExecutor`**: apply a configurable `CommandTimeout` to every command, and **rethrow** query failures instead of masking them as "Cannot find table 0". A negative `CommandTimeout` is clamped to `0` (SqlClient otherwise throws); `0` means no timeout.
- **`NotFoundHandlerOptions.CommandTimeout`** (seconds, default `30`) so large sites can raise it past the SqlClient default.
- **`IContentUrlHistoryLoader` / `SqlContentUrlHistoryRepository`**: add a paged `GetAllMoved(int skip, int take)` using `OFFSET ... FETCH NEXT` over the moved keys, and reimplement the parameterless `GetAllMoved()` to stream pages so the unbounded query is gone everywhere. (`md5_ContentKey` is the hash of `ContentKey`, so each key maps to a single group and is never split across a page boundary.) The paged query short-circuits to an empty result when `take <= 0` and clamps a negative `skip`, so a bad caller can't emit invalid SQL.
- **`RegisterMovedContentRedirectsJob`**: process the table page-by-page (stoppable, with progress logging) instead of materialising it all up front. Page size is tunable via **`OptimizelyNotFoundHandlerOptions.MovedContentBatchSize`** (default `1000`) and is clamped to `>= 1`. `CreateRedirects` only writes to the redirects store, not `ContentUrlHistory`, so the moved set is stable for the run and skip-based paging never skips a key.

## Compatibility notes

- **`IContentUrlHistoryLoader.GetAllMoved(int skip, int take)` ships as a default interface method** (pages in-memory over `GetAllMoved()`), so existing third-party implementations keep compiling without any change. Data-backed stores should override it with a server-side paged query, as `SqlContentUrlHistoryRepository` does — the in-memory default still materialises the full set, so it is a source-compatibility shim, not a scalability path.
- **`SqlDataExecutor.ExecuteQuery` now propagates exceptions** that were previously swallowed. This is intentional (so failures surface instead of becoming "Cannot find table 0"), but it changes behaviour for any caller that relied on getting an empty table back on error. The 404 request hot path is unaffected: redirect lookups during a request read the in-memory `CustomRedirectCollection` (`CustomRedirectHandler.Find`), not a live query. The change affects collection (re)loads and admin/reporting reads, which now surface a real error instead of silently returning nothing.

## Tests

- Repository: paging passes the right `skip`/`take`, groups histories by content key, stops paging on a short page, and returns empty without querying when `take <= 0`.
- Job: processes every page across batches, does not fetch a further page after a partial page, stops after the empty page when the total is an exact multiple of the batch size, clamps a non-positive batch size to one, and continues when an individual item fails.

Built and tested on **.NET 8**: **60 pass in `Geta.NotFoundHandler.Tests`, 60 pass in `Geta.NotFoundHandler.Optimizely.Tests`**, 0 failures.

Generated with [Claude Code](https://claude.com/claude-code)
